### PR TITLE
FIX: LiveCD SELinux, one-terminal build, and container quickstart doc

### DIFF
--- a/Build_Remix.sh
+++ b/Build_Remix.sh
@@ -14,6 +14,10 @@ show_usage() {
     echo "                           Examples: FedoraRemix, FedoraRemixCosmic"
     echo "  -l, --list               List available kickstart files"
     echo "  -h, --help               Show this help message"
+    echo "  -a, --attach             Interactive: attach to the container (podman run -it)."
+    echo "                           Default is detached: build runs in background, this"
+    echo "                           script streams /tmp/entrypoint.log in this terminal"
+    echo "                           until the build finishes (no second window needed)."
     echo ""
     echo "If no kickstart is specified, you will be prompted to choose."
 }
@@ -102,11 +106,17 @@ SOURCE_DIR="$CURRENT_DIR"
 
 # Parse command line arguments
 SELECTED_KICKSTART=""
+# 0 = default: run detached, stream build log in this shell
+ATTACH_MODE=0
 while [[ $# -gt 0 ]]; do
     case $1 in
         -k|--kickstart)
             SELECTED_KICKSTART="$2"
             shift 2
+            ;;
+        -a|--attach)
+            ATTACH_MODE=1
+            shift
             ;;
         -l|--list)
             # List kickstarts from current directory (source)
@@ -124,6 +134,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Environment override (e.g. REMIX_BUILD_ATTACH=1 ./Build_Remix.sh)
+if [ "${REMIX_BUILD_ATTACH:-0}" = "1" ]; then
+    ATTACH_MODE=1
+fi
 
 # Check if config.yml exists
 if [ ! -f "config.yml" ]; then
@@ -258,6 +273,76 @@ else
     EXTRA_ARGS=("--device-cgroup-rule=b 7:* rmw")
 fi
 
+# After `podman run -d`, stream /tmp/entrypoint.log in the foreground (same terminal).
+# Stops when /tmp/entrypoint-status exists (or legacy /tmp/entrypoint-completed) or
+# remix-builder.service fails, or a max wait is exceeded.
+stream_remix_entrypoint_log() {
+    local name=$1
+    local cap=${2:-21600}
+    local waited=0
+    # Wait for container and log to appear
+    while [ "$waited" -lt 300 ]; do
+        if $PODMAN_CMD ps -q -f "name=^${name}$" 2>/dev/null | grep -q .; then
+            if $PODMAN_CMD exec "$name" test -f /tmp/entrypoint.log 2>/dev/null; then
+                break
+            fi
+        else
+            if ! $PODMAN_CMD ps -a -q -f "name=^${name}$" 2>/dev/null | grep -q .; then
+                echo "Error: container ${name} is not running (exited before entrypoint log was created)."
+                return 1
+            fi
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if [ "$waited" -ge 300 ]; then
+        echo "Error: timed out waiting for /tmp/entrypoint.log in ${name}."
+        return 1
+    fi
+    echo "Streaming build log from ${name}:/tmp/entrypoint.log (Ctrl-C stops follow only; container keeps running)..."
+    set +e
+    $PODMAN_CMD exec -i "$name" bash -s "$cap" <<'REMIX_STREAM'
+set +e
+max_s=$1
+tail -n 200 -F /tmp/entrypoint.log 2>/dev/null &
+TAILPID=$!
+i=0
+while [ "$i" -lt "$max_s" ]; do
+    if [ -f /tmp/entrypoint-status ]; then break; fi
+    if [ -f /tmp/entrypoint-completed ]; then break; fi
+    if systemctl is-failed --quiet remix-builder.service 2>/dev/null; then break; fi
+    if ! kill -0 $TAILPID 2>/dev/null; then break; fi
+    i=$((i + 1))
+    sleep 1
+done
+# Drain last lines
+sleep 2
+kill $TAILPID 2>/dev/null
+wait $TAILPID 2>/dev/null
+exit 0
+REMIX_STREAM
+    set -e
+    local s
+    s=$($PODMAN_CMD exec "$name" cat /tmp/entrypoint-status 2>/dev/null | tr -d '\r' || true)
+    if [ "$s" = "ok" ]; then
+        echo ""
+        echo "Build entrypoint completed successfully (status: ok)."
+        return 0
+    fi
+    if echo "$s" | grep -q '^failed:'; then
+        echo ""
+        echo "Build entrypoint failed (${s})."
+        return 1
+    fi
+    if $PODMAN_CMD exec "$name" test -f /tmp/entrypoint-completed; then
+        echo ""
+        echo "Build entrypoint completed (entrypoint-completed; older image without entrypoint-status)."
+        return 0
+    fi
+    echo "Could not determine final build status. Check: $PODMAN_CMD exec -it $name cat /tmp/entrypoint.log"
+    return 1
+}
+
 # Run the container with systemd support and loop device access
 # Note: --security-opt label=disable helps with SELinux-related mount warnings
 # --replace will automatically replace any existing container with the same name
@@ -265,16 +350,25 @@ fi
 # Pass the selected kickstart as an environment variable
 # SOURCE_DIR is mounted as workspace (contains kickstarts, scripts, etc.)
 # FEDORA_REMIX_LOCATION is mounted as output directory for ISO creation
-$PODMAN_CMD run --rm -it \
-    --replace \
-    --name "$CONTAINER_NAME" \
-    --systemd=always \
-    --privileged \
-    "${EXTRA_ARGS[@]}" \
-    --security-opt label=disable \
-    -e "REMIX_KICKSTART=$SELECTED_KICKSTART" \
-    -v "$SSH_KEY_LOCATION:/root/github_id:ro" \
-    -v "$FEDORA_REMIX_LOCATION:/livecd-creator:rw" \
-    -v "$SOURCE_DIR:/root/workspace:rw" \
-    "$IMAGE_NAME"
+
+RUN_ARGS=("--replace" "--name" "$CONTAINER_NAME" "--systemd=always" "--privileged" "${EXTRA_ARGS[@]}"
+  "--security-opt" "label=disable" "-e" "REMIX_KICKSTART=$SELECTED_KICKSTART"
+  "-v" "$SSH_KEY_LOCATION:/root/github_id:ro" "-v" "$FEDORA_REMIX_LOCATION:/livecd-creator:rw" "-v" "$SOURCE_DIR:/root/workspace:rw" "$IMAGE_NAME")
+
+if [ "$ATTACH_MODE" = "1" ]; then
+    echo "Interactive attach: build output is not auto-streamed; use tail/journal in another shell if needed."
+    $PODMAN_CMD run --rm -it "${RUN_ARGS[@]}"
+else
+    echo "Container runs detached; this terminal will follow /tmp/entrypoint.log until the build step finishes."
+    if ! $PODMAN_CMD run -d --rm "${RUN_ARGS[@]}"; then
+        echo "Error: failed to start builder container"
+        exit 1
+    fi
+    if ! stream_remix_entrypoint_log "$CONTAINER_NAME" 21600; then
+        echo "The container may still be running: $PODMAN_CMD ps -a -f name=$CONTAINER_NAME"
+        exit 1
+    fi
+    echo "Container is still running for shell inspection. Example:  $PODMAN_CMD exec -it $CONTAINER_NAME bash"
+    echo "When finished, stop it with:  $PODMAN_CMD stop $CONTAINER_NAME"
+fi
 

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -1,6 +1,6 @@
 # Fedora Remix Builder - Container Quickstart Guide
 
-**Last Updated:** April 13, 2026  
+**Last Updated:** April 22, 2026  
 **Purpose:** Quick guide to building a custom Fedora Remix ISO using the containerized build system
 
 ---
@@ -38,8 +38,26 @@ Before starting, ensure your system has:
    sudo apt install podman
    ```
 
-3. **Sudo Access** - Required for loop device creation on Linux
+3. **Vim** (or another editor) - The steps below use `vim` to edit configuration files
+   ```bash
+   # Fedora/RHEL
+   sudo dnf install vim
+   ```
+   You can use `nano` or a graphical editor instead; replace `vim` in the commands in this guide with whatever you prefer.
+
+4. **Sudo Access** - Required for loop device creation on Linux
    - The build script will automatically use `sudo` when needed
+
+#### Optional: tools for testing the built ISO in a local VM (Fedora host)
+
+If you plan to boot and test the ISO on the **same** machine (for example with **virt-manager**), install the virtualization stack:
+
+```bash
+sudo dnf install virt-manager libvirt qemu
+sudo systemctl enable libvirtd --now
+```
+
+Without these packages you can still **build** the ISO; you would test it on another system, on bare metal, or by installing a VM stack later.
 
 ### System Requirements
 
@@ -170,7 +188,27 @@ Otherwise, run the build script directly:
 ./Build_Remix.sh
 ```
 
-**Build Process:**
+**Build Process (default):** The script starts the container **detached** and **streams the build** by following `/tmp/entrypoint.log` **in the same terminal** (you do not need a second window or `podman exec` just to watch progress). A typical run looks like:
+
+1. Container starts with systemd.
+2. Message that the container runs detached and this terminal will follow the log.
+3. Prepares build environment (patches, cache, and so on).
+4. Downloads and installs packages (often the longest phase).
+5. Runs post-installation scripts and creates the ISO.
+6. When the **build step inside the entrypoint** finishes, the log follow stops. The script prints a short **success or failure** line, then something like: the **container is still running** for inspection, with examples for a shell: `podman exec -it remix-builder bash` (or `sudo podman` on Linux if your script uses it).
+
+**Stopping the container when you are done**  
+The build container is only needed while you want to **inspect** the build environment. When you are finished (or to free resources before using the machine for something else), stop it (use `sudo` the same way you do for `podman` in your setup):
+
+```bash
+podman stop remix-builder
+```
+
+On Linux, if the script used `sudo podman` to start the container, use `sudo podman stop remix-builder`.
+
+**Interactive attach (optional):** If you want the old behavior and attach the terminal directly to the container (no host-side log follow), use `./Build_Remix.sh --attach` or set `REMIX_BUILD_ATTACH=1` before running the script.
+
+**Build Process (summary):**
 1. Container starts with systemd
 2. Prepares build environment
 3. Downloads and installs packages (~15-20 minutes)
@@ -480,9 +518,13 @@ Error: Not enough free space
 
 ## Build Output
 
+### After the log follow ends
+
+When you run `./Build_Remix.sh` in the default mode, your terminal shows the **same** build output that is written to `/tmp/entrypoint.log` in the container. After the **remix-builder** entrypoint completes, the script prints whether the build **succeeded** or **failed** and reminds you that the **container is still running**. Use **`podman stop remix-builder`** (with `sudo` if your build used `sudo podman`) to stop it when you no longer need a shell inside the container.
+
 ### Successful Build
 
-**Expected output:**
+**Expected output (excerpt from the end of the build log):**
 ```
 ✅ 🚀 Live CD created successfully!
   🕐 Total Build Time:          30m 46s (1846 seconds)
@@ -524,7 +566,8 @@ Error: Not enough free space
    ```
 
 2. **Test in a VM:**
-   - Use GNOME Boxes, VirtualBox, or virt-manager
+   - If you installed **virt-manager**, **libvirt**, and **qemu** (and enabled **libvirtd**) as described in **Prerequisites** (optional VM testing tools), use **virt-manager** on the same machine
+   - Otherwise use GNOME Boxes, VirtualBox, or another hypervisor
    - Boot from the ISO
    - Test Live environment
    - Test installation
@@ -635,7 +678,7 @@ done
 2. Edit `config.yml` - Set container properties
 3. Edit `Setup/config.yml` - Set remix version (must match!)
 4. Run `./Verify_Build_Remix.sh` - Verify and build
-5. Wait 30-45 minutes
+5. Wait 30-45 minutes (build log streams in the same terminal; when the follow step ends, run `podman stop remix-builder` if you are done with the container)
 6. Find ISO at `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
 
 **Optional Customization:**
@@ -648,5 +691,5 @@ done
 
 ---
 
-**Last Updated:** April 13, 2026  
-**Version:** 1.0
+**Last Updated:** April 22, 2026  
+**Version:** 1.1

--- a/Setup/Kickstarts/Extra/FlatRemix.ks
+++ b/Setup/Kickstarts/Extra/FlatRemix.ks
@@ -19,8 +19,8 @@ repo --name="rpmfusionnon-nonfree" --mirrorlist=https://mirrors.rpmfusion.org/me
 repo --name="GithubCLITools" --baseurl=https://cli.github.com/packages/rpm
 # Root password
 rootpw --iscrypted --lock locked
-# SELinux configuration
-selinux --enforcing
+# SELinux (permissive — match fedora-live-base / container build reality)
+selinux --permissive
 # System services
 services --disabled="sshd" --enabled="NetworkManager,ModemManager"
 # System timezone

--- a/Setup/Kickstarts/fedora-live-base.ks
+++ b/Setup/Kickstarts/fedora-live-base.ks
@@ -10,7 +10,9 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-selinux --enforcing
+# Permissive: container livecd-creator setfiles is often incomplete; permissive avoids
+# GDM/session breakages on live boot without a long first-boot relabel.
+selinux --permissive
 firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr


### PR DESCRIPTION
## Summary

Three related updates for **containerized ISO builds**, the **live image**, and **documentation**:

1. **SELinux permissive** in the live kickstarts so the LiveCD/Live USB stays usable when `setfiles` does not complete cleanly in the livecd chroot (common in the builder container).
2. **`Build_Remix.sh`**: by default, start the builder with **`podman run -d`**, then **stream `/tmp/entrypoint.log` in the same host terminal** so you do not need a second window and `podman exec` just to watch the build; document **`podman stop remix-builder`** when finished.
3. **`Quickstart_Container.md`**: prerequisites (including **vim**), optional **virt-manager / libvirt / qemu** for local VM testing with **`systemctl enable libvirtd --now`**, and steps aligned with the new build/stop flow.

**Related container image work** (status files, console/journal): [RemixBuilder PR #2](https://github.com/tmichett/RemixBuilder/pull/2) — rebuild and use the updated `ghcr.io/.../fedora-remix-builder` image for the full experience.

---

## 1. SELinux: permissive for the live system

### Problem

- The patched `kickstart.py` can allow the build to finish when relabeling fails in the chroot, leaving **incomplete file contexts** with **enforcing** in `/etc/selinux/config`.
- On the live system that can show up as **GDM / session** issues and confusing **`gkr-pam`** / keyring lines in the journal.

### Change

- **`Setup/Kickstarts/fedora-live-base.ks`:** `selinux --permissive` (replaces `--enforcing`); no **`/.autorelabel`** (avoids a long one-time first boot in favor of permissive on the live session).
- **`Setup/Kickstarts/Extra/FlatRemix.ks`:** `selinux --permissive` for consistency with the base live template.

### Notes

- **Permissive** still loads the policy and **logs** denials; it does not enforce MAC on the live session like enforcing.
- After **install to disk**, you can move to **enforcing** on the installed system after a proper relabel if you want (e.g. `fixfiles onboot` on the target).

---

## 2. `Build_Remix.sh`: one terminal for the build log

### Problem

With **`podman run -it`**, the container console, `console-getty`, and the build service can be hard to read; **journald** and **`/tmp/entrypoint.log`** had the truth, but that required **another** shell and **`podman exec`** to follow.

### Change (default path)

- Start the container with **`podman run -d --rm`** (detached).
- Wait for **`/tmp/entrypoint.log`**, then run **`tail -F`** on it **in the foreground** in the same script (function `stream_remix_entrypoint_log`) until:
  - **`/tmp/entrypoint-status`** is present (`ok` or `failed:*`) — written by **`entrypoint.sh` in the RemixBuilder image** on exit, or
  - legacy **`/tmp/entrypoint-completed`**, or
  - **`remix-builder.service`** is in the **failed** state.
- Max follow wait: **21600 s (6 h)** (tunable as the second argument to the helper in script).
- On success, print hints to **`exec`** a shell or **`stop`** the still-running container (`podman stop remix-builder`, with `sudo` when the build used `sudo podman`).

### Optional: previous behavior

- **`-a` / `--attach`** or **`REMIX_BUILD_ATTACH=1`**: use **`podman run --rm -it`** and attach to the container (no automatic `tail` in the host script; use `tail` / `journalctl` inside the container as before).

---

## 3. `Quickstart_Container.md` documentation

- **Prerequisites:** add **vim** (`sudo dnf install vim`) as a required tool for the examples in the guide; note that any editor can be used.
- **Optional (local VM testing):** `sudo dnf install virt-manager libvirt qemu` and `sudo systemctl enable libvirtd --now`, with a note that the ISO can still be built and tested elsewhere without this stack.
- **Step 5 / build output / summary:** describe the **default detached + log follow** flow, what appears when the build step ends, **`podman stop remix-builder`** (and `sudo` when needed), and **`--attach`** for the old mode.
- **Next steps (testing the ISO):** tie **virt-manager** to the optional prerequisite when applicable.
- **Metadata:** last updated and doc version bump.

---

## Related

- Linux / SELinux / container build notes in this repo (e.g. `LINUX_BUILD_FIX.md`).
- [RemixBuilder #2](https://github.com/tmichett/RemixBuilder/pull/2) for **`Containerfile`**, **`entrypoint.sh`**, and compatibility with the follow script above.