### PR TITLE
fix: SELinux-aware Podman for container builds (Fix #3b)

### DIFF
--- a/Build_Remix.sh
+++ b/Build_Remix.sh
@@ -273,6 +273,12 @@ else
     EXTRA_ARGS=("--device-cgroup-rule=b 7:* rmw")
 fi
 
+# :z relabels bind mounts for SELinux (shared); omit on non-Linux hosts (e.g. macOS Podman VM)
+VOL_Z=""
+if [ "$(uname -s)" = "Linux" ]; then
+    VOL_Z=",z"
+fi
+
 # After `podman run -d`, stream /tmp/entrypoint.log in the foreground (same terminal).
 # Stops when /tmp/entrypoint-status exists (or legacy /tmp/entrypoint-completed) or
 # remix-builder.service fails, or a max wait is exceeded.
@@ -344,7 +350,9 @@ REMIX_STREAM
 }
 
 # Run the container with systemd support and loop device access
-# Note: --security-opt label=disable helps with SELinux-related mount warnings
+# Do NOT use --security-opt label=disable: with host SELinux enforcing, Podman needs
+# proper labels on bind mounts so setfiles inside livecd-creator can relabel the chroot.
+# Volume suffix :z relabels content for shared container access (see LINUX_BUILD_FIX.md).
 # --replace will automatically replace any existing container with the same name
 # The /sys unmount issue is now handled gracefully by Enhanced_Remix_Build_Script.sh
 # Pass the selected kickstart as an environment variable
@@ -352,8 +360,8 @@ REMIX_STREAM
 # FEDORA_REMIX_LOCATION is mounted as output directory for ISO creation
 
 RUN_ARGS=("--replace" "--name" "$CONTAINER_NAME" "--systemd=always" "--privileged" "${EXTRA_ARGS[@]}"
-  "--security-opt" "label=disable" "-e" "REMIX_KICKSTART=$SELECTED_KICKSTART"
-  "-v" "$SSH_KEY_LOCATION:/root/github_id:ro" "-v" "$FEDORA_REMIX_LOCATION:/livecd-creator:rw" "-v" "$SOURCE_DIR:/root/workspace:rw" "$IMAGE_NAME")
+  "-e" "REMIX_KICKSTART=$SELECTED_KICKSTART"
+  "-v" "$SSH_KEY_LOCATION:/root/github_id:ro${VOL_Z}" "-v" "$FEDORA_REMIX_LOCATION:/livecd-creator:rw${VOL_Z}" "-v" "$SOURCE_DIR:/root/workspace:rw${VOL_Z}" "$IMAGE_NAME")
 
 if [ "$ATTACH_MODE" = "1" ]; then
     echo "Interactive attach: build output is not auto-streamed; use tail/journal in another shell if needed."

--- a/LINUX_BUILD_FIX.md
+++ b/LINUX_BUILD_FIX.md
@@ -1,6 +1,6 @@
 # Fedora Remix Builder - Linux Compatibility Fixes
 
-**Last Updated:** April 13, 2026
+**Last Updated:** April 22, 2026
 **Status:** RESOLVED
 
 ## Fix History
@@ -17,24 +17,28 @@ setfiles: Could not set context for /usr/share/accountsservice/interfaces: Inval
 Error creating Live CD : SELinux relabel failed.
 ```
 
-**Root Cause:**
-- `livecd-creator` uses `imgcreate/kickstart.py` to relabel all files in the ISO with SELinux contexts
-- When building in containers, the SELinux contexts from the host system don't match the container's expectations
-- The `setfiles` command fails because it cannot apply contexts to certain system directories
-- The `SelinuxConfig.relabel()` method raises a fatal error when relabeling fails in enforcing mode
-- This is particularly problematic for files in `/usr/share/accountsservice` and similar system directories
+**Root Cause (container builds):**
+- `livecd-creator` uses `imgcreate/kickstart.py` to relabel the chroot with `setfiles`.
+- With **`podman run --security-opt label=disable`** and bind mounts **without** SELinux volume options, the build environment often could not complete relabeling the same way as on a bare Fedora host.
 
-**Solution:**
-- Patched `imgcreate/kickstart.py` to handle SELinux relabeling failures gracefully
-- Changed the error from fatal (`raise errors.KickstartError`) to a warning (`logging.warning`)
-- The ISO will be properly relabeled on first boot when installed on a target system
-- This is safe and follows the same pattern as the `/sys` unmount fix
+**Interim workaround (April 13 – April 22, 2026):** Patched `kickstart.py` to log relabel failure as a warning instead of aborting, and used **`selinux --permissive`** in the live kickstart so incomplete labels were less harmful on the Live image. That path is **no longer the default** after Fix #3b.
 
-**Files Modified:**
-- `Setup/files/Fixes/kickstart.py` (lines 499-503): Changed fatal error to warning for SELinux relabel failures
-- `Setup/Enhanced_Remix_Build_Script.sh` (line 265): Added informational message about the patch
+### Fix #3b: SELinux-aware Podman for container builds (April 2026)
 
-**Result:** ✅ ISO builds now complete successfully with SELinux relabeling errors logged as warnings
+**Goal:** Run **`setfiles` successfully** inside the RemixBuilder container so the Live image can use **`selinux --enforcing`** and `kickstart.py` can **fail the build** again if relabel fails.
+
+**Changes:**
+- **`Build_Remix.sh`:** Remove **`--security-opt label=disable`**. On **Linux** hosts, add the **`:z` suffix** on bind mounts (`:ro,z` / `:rw,z`) so Podman relabels host paths for shared container access under SELinux. On **non-Linux** hosts (for example macOS with Podman Machine), the suffix is omitted because `:z` is not applicable there.
+- **`Setup/files/Fixes/kickstart.py`:** Restore **strict** behavior: on enforcing kickstart, **`setfiles` non-zero exit raises `KickstartError`** again.
+- **`Setup/Kickstarts/fedora-live-base.ks`** (and **`Extra/FlatRemix.ks`**): Restore **`selinux --enforcing`** for the product in the ISO.
+
+**Still in place:** `Enhanced_Remix_Build_Script.sh` runs **`setenforce 0`** inside the container during the build so the **container runtime** stays permissive while tools run; that is independent of **`selinux --enforcing`** in the **kickstart** (the tree that becomes the ISO).
+
+**If the build still fails with AVCs on the host:** from the host (not inside the container), inspect denials (`ausearch -m avc -ts recent`) and adjust host policy or paths; ensure the output and workspace directories are on a filesystem that supports xattrs.
+
+### Reference: non-container builds (VM / physical host)
+
+On a normal Fedora **build VM** without Podman’s `label=disable`, **`setfiles` completes** during `livecd-creator` and the Live image can run **SELinux enforcing** — same kickstart behavior as Fix #3b when the container path is healthy.
 
 ---
 
@@ -506,13 +510,7 @@ $PODMAN_CMD run --rm -it \
 
 **Why**: Automatically replaces stuck containers instead of failing
 
-**Change 6**: Added `--security-opt label=disable`
-
-```bash
---security-opt label=disable \
-```
-
-**Why**: Prevents SELinux-related mount warnings
+**Change 6** (superseded April 2026): Previously added `--security-opt label=disable` to silence mount warnings; that prevented reliable **`setfiles`** relabel in the chroot. **Fix #3b** removes it and uses **`:z` on `-v` mounts** in `Build_Remix.sh` instead so host SELinux and container relabel work together.
 
 ---
 

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -472,17 +472,15 @@ Error creating Live CD : SELinux relabel failed.
 ```
 
 **Solution:**
-This is fixed in the latest version. Ensure you have the patched `kickstart.py`:
-```bash
-ls -lh Setup/files/Fixes/kickstart.py
-```
+`Build_Remix.sh` is configured for **host SELinux**: bind mounts use **`:z`** and **`--security-opt label=disable` is not used**, so `setfiles` inside the container can complete. Ensure you are on a current `Fedora_Remix` tree and that **`Setup/files/Fixes/kickstart.py`** is present (the build installs it into `imgcreate`).
 
-If missing, pull the latest changes:
-```bash
-git pull origin main
-```
+If relabel still fails:
 
-See `SELINUX_RELABEL_FIX.md` for details.
+1. On the **host** (Fedora), check for denials: `sudo ausearch -m avc -ts recent`
+2. Confirm output and workspace paths support extended attributes (avoid odd network-only mounts for the ISO output tree if possible)
+3. See **`LINUX_BUILD_FIX.md`** (Fix #3 / Fix #3b) for the full write-up
+
+Historical note: `SELINUX_RELABEL_FIX.md` describes an older “warn and continue” approach; the default is again **strict relabel** with **enforcing** in the live kickstart when the container setup is correct.
 
 ### Build Fails After 15 Minutes
 

--- a/SELINUX_RELABEL_FIX.md
+++ b/SELINUX_RELABEL_FIX.md
@@ -2,7 +2,9 @@
 
 **Date:** April 13, 2026  
 **Issue:** ISO creation fails with SELinux relabeling errors  
-**Status:** ✅ FIXED
+**Status:** ✅ FIXED (historical document)
+
+> **April 2026 update:** The default approach is now **SELinux-aware Podman** (`:z` on volume mounts, **no** `label=disable`) plus **strict** `kickstart.py` relabel and **`selinux --enforcing`** in the live kickstart. See **`LINUX_BUILD_FIX.md`** (Fix #3 and **Fix #3b**). The sections below describe the earlier **warning-only** patch for context.
 
 ## Problem Summary
 

--- a/Setup/Enhanced_Remix_Build_Script.sh
+++ b/Setup/Enhanced_Remix_Build_Script.sh
@@ -263,7 +263,7 @@ run_build() {
     
     print_message "INFO" "${ROCKET} Launching build process..."
     print_message "INFO" "${TARGET} Command: $build_cmd"
-    print_message "INFO" "${WRENCH} Note: SELinux relabeling errors are handled gracefully via patched kickstart.py"
+    print_message "INFO" "${WRENCH} Note: If SELinux relabel fails, fix container/volume SELinux (see LINUX_BUILD_FIX.md); build will abort on relabel error when enforcing."
     
     # Add build command section to log
     {

--- a/Setup/Kickstarts/Extra/FlatRemix.ks
+++ b/Setup/Kickstarts/Extra/FlatRemix.ks
@@ -19,8 +19,8 @@ repo --name="rpmfusionnon-nonfree" --mirrorlist=https://mirrors.rpmfusion.org/me
 repo --name="GithubCLITools" --baseurl=https://cli.github.com/packages/rpm
 # Root password
 rootpw --iscrypted --lock locked
-# SELinux (permissive — match fedora-live-base / container build reality)
-selinux --permissive
+# SELinux configuration
+selinux --enforcing
 # System services
 services --disabled="sshd" --enabled="NetworkManager,ModemManager"
 # System timezone

--- a/Setup/Kickstarts/fedora-live-base.ks
+++ b/Setup/Kickstarts/fedora-live-base.ks
@@ -10,9 +10,7 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-# Permissive: container livecd-creator setfiles is often incomplete; permissive avoids
-# GDM/session breakages on live boot without a long first-boot relabel.
-selinux --permissive
+selinux --enforcing
 firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr

--- a/Setup/files/Fixes/kickstart.py
+++ b/Setup/files/Fixes/kickstart.py
@@ -497,12 +497,10 @@ class SelinuxConfig(KickstartConfig):
                 logging.info('The setfiles command is not available.')
                 return
         if rc:
-            # In containerized builds, SELinux relabeling often fails due to context mismatches
-            # This is safe to ignore as the ISO will be relabeled on first boot or installation
             if ksselinux.selinux == ksconstants.SELINUX_ENFORCING:
-                logging.warning("SELinux relabel failed in container environment. This is expected and safe - the system will be relabeled on first boot.")
+                raise errors.KickstartError("SELinux relabel failed.")
             else:
-                logging.warning("SELinux relabel failed in container environment. This is expected and safe.")
+                logging.error("SELinux relabel failed.")
 
     def apply(self, ksselinux):
         selinux_config = "/etc/selinux/config"


### PR DESCRIPTION
## Summary

**Fix #3b** adjusts how the Remix build runs in Podman on **SELinux-enforcing** Fedora hosts so `livecd-creator` can complete **strict** `setfiles` relabeling inside the chroot. This replaces the interim approach (`--security-opt label=disable` and warning-only `kickstart.py` relabel) with **labeled bind mounts** and **enforcing** in the live kickstart when the container path is healthy.

## What changed

- **`Build_Remix.sh`**: Dropped `--security-opt label=disable`. On **Linux** hosts, bind mounts use the **`:z`** suffix (`:ro,z` / `:rw,z`) for shared container labeling; on **non-Linux** hosts (e.g. macOS + Podman Machine) the suffix is omitted.
- **`Setup/files/Fixes/kickstart.py`**: Restores **strict** relabel: when the kickstart requests **enforcing** SELinux, a non-zero `setfiles` exit **raises** `KickstartError` again.
- **`Setup/Kickstarts/fedora-live-base.ks`** and **`Setup/Kickstarts/Extra/FlatRemix.ks`**: Restored **`selinux --enforcing`** for the product in the image.
- **Docs**: **`LINUX_BUILD_FIX.md`**, **`Quickstart_Container.md`**, **`SELINUX_RELABEL_FIX.md`**, and a log line in **`Setup/Enhanced_Remix_Build_Script.sh`** updated to document Fix #3b and point to `LINUX_BUILD_FIX.md` for AVC troubleshooting.

## Notes

- **`Enhanced_Remix_Build_Script.sh`** still may use **`setenforce 0`** inside the container for the build runtime; that is separate from **`selinux --enforcing`** in the **kickstart** (the tree that becomes the live ISO).
- If the build still fails with **AVC** on the host, inspect `ausearch -m avc -ts recent` and see **`LINUX_BUILD_FIX.md`**.

## Test plan

- [ ] Build the remix on a **Fedora Linux** host with SELinux **enforcing**; confirm the container starts without `label=disable` and the ISO build completes with relabel **not** downgraded to warnings only.
- [ ] (Optional) Confirm **Podman** on a **non-Linux** path still works with **no** `:z` suffix (script logic for `uname -s`).
