### PR TITLE
feat: add Build_Remix_Physical.sh for native (non-container) ISO builds

### DIFF
--- a/Build_Remix_Physical.sh
+++ b/Build_Remix_Physical.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+#
+# Build_Remix_Physical.sh
+# Native (non-container) Fedora Remix build: update Setup/config.yml, run
+# prepare scripts, then livecd-creator via Enhanced_Remix_Build_Script.sh
+#
+
+set -e
+
+# Color definitions
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly CYAN='\033[0;36m'
+readonly WHITE='\033[1;37m'
+readonly BOLD='\033[1m'
+readonly NC='\033[0m'
+
+readonly CHECKMARK="✅"
+readonly CROSS="❌"
+readonly WARNING="⚠️"
+readonly INFO="ℹ️"
+readonly ROCKET="🚀"
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SETUP_DIR="$SCRIPT_DIR/Setup"
+readonly SETUP_CONFIG="$SETUP_DIR/config.yml"
+readonly LIVECD_WORKDIR="/livecd-creator/FedoraRemix"
+readonly PREPARE_BUILD="$SETUP_DIR/Prepare_Fedora_Remix_Build.py"
+readonly PREPARE_WEB="$SETUP_DIR/Prepare_Web_Files.py"
+readonly ENHANCED_SCRIPT="$SETUP_DIR/Enhanced_Remix_Build_Script.sh"
+
+SELECTED_KICKSTART=""
+
+print_message() {
+    local level="$1"
+    local message="$2"
+
+    case "$level" in
+        "SUCCESS")
+            echo -e "${GREEN}${CHECKMARK} ${message}${NC}"
+            ;;
+        "ERROR")
+            echo -e "${RED}${CROSS} ${message}${NC}"
+            ;;
+        "WARNING")
+            echo -e "${YELLOW}${WARNING} ${message}${NC}"
+            ;;
+        "INFO")
+            echo -e "${CYAN}${INFO} ${message}${NC}"
+            ;;
+        "HEADER")
+            echo -e "${BOLD}${CYAN}╔══════════════════════════════════════════════════════════════════════╗${NC}"
+            echo -e "${BOLD}${CYAN}║${NC} ${WHITE}${message}${NC}"
+            echo -e "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════════════╝${NC}"
+            ;;
+    esac
+}
+
+show_usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Interactive native build: sets fedora_version in Setup/config.yml,"
+    echo "runs Prepare_Fedora_Remix_Build.py and Prepare_Web_Files.py, then"
+    echo "Enhanced_Remix_Build_Script.sh under ${LIVECD_WORKDIR}."
+    echo ""
+    echo "Options:"
+    echo "  -v, --version <n>     Fedora release number (e.g. 43). If omitted, you are prompted."
+    echo "  -k, --kickstart <name> Kickstart base name without .ks (e.g. FedoraRemixCosmic)"
+    echo "  -l, --list            List available kickstart files"
+    echo "  -h, --help            Show this help"
+    echo ""
+    echo "Must be run on the machine where /livecd-creator will be used; prepare"
+    echo "and build steps require root (sudo)."
+}
+
+list_kickstarts() {
+    local base="$1"
+    echo "Available kickstart base names:"
+    echo ""
+    for ks in "$base"/Setup/Kickstarts/FedoraRemix*.ks; do
+        if [ -f "$ks" ]; then
+            basename "$ks" .ks
+        fi
+    done
+}
+
+show_kickstart_menu() {
+    local remix_location="$1"
+    local kickstarts=()
+    local i=1
+
+    if [ -f "$remix_location/Setup/Kickstarts/FedoraRemix.ks" ]; then
+        kickstarts+=("FedoraRemix")
+    fi
+
+    for ks in "$remix_location"/Setup/Kickstarts/FedoraRemix*.ks; do
+        if [ -f "$ks" ]; then
+            local name
+            name=$(basename "$ks" .ks)
+            if [[ "$name" != *"Packages"* ]] && [[ "$name" != *"Repos"* ]] && [ "$name" != "FedoraRemix" ]; then
+                kickstarts+=("$name")
+            fi
+        fi
+    done
+
+    echo ""
+    echo -e "${CYAN}╔══════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║${NC} ${WHITE}${ROCKET}  Fedora Remix — Kickstart Selection (physical)${NC}     ${CYAN}║${NC}"
+    echo -e "${CYAN}╠══════════════════════════════════════════════════════╣${NC}"
+
+    for name in "${kickstarts[@]}"; do
+        if [ "$name" = "FedoraRemix" ]; then
+            echo -e "${CYAN}║${NC}  ${GREEN}$i)${NC} ${WHITE}$name${NC}$(printf '%*s' $((39 - ${#name})) '')${YELLOW}[DEFAULT]${NC} ${CYAN}║${NC}"
+        else
+            echo -e "${CYAN}║${NC}  ${GREEN}$i)${NC} $name$(printf '%*s' $((49 - ${#name})) '')${CYAN}║${NC}"
+        fi
+        ((i++)) || true
+    done
+
+    echo -e "${CYAN}╚══════════════════════════════════════════════════════╝${NC}"
+    echo ""
+
+    while true; do
+        read -r -p "Select kickstart (1-${#kickstarts[@]}) [Enter=default]: " choice
+        if [ -z "$choice" ]; then
+            SELECTED_KICKSTART="FedoraRemix"
+            echo "Using default: FedoraRemix"
+            break
+        elif [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#kickstarts[@]}" ]; then
+            SELECTED_KICKSTART="${kickstarts[$((choice - 1))]}"
+            break
+        else
+            echo "Invalid selection. Enter 1-${#kickstarts[@]} or press Enter for default."
+        fi
+    done
+}
+
+get_remix_fedora_version() {
+    if [ ! -f "$SETUP_CONFIG" ]; then
+        echo "ERROR: Setup/config.yml not found"
+        return 1
+    fi
+    local version
+    version=$(grep "^fedora_version:" "$SETUP_CONFIG" | awk '{print $2}' | tr -d '"')
+    if [ -z "$version" ]; then
+        echo "ERROR: Could not extract fedora_version from Setup/config.yml"
+        return 1
+    fi
+    echo "$version"
+}
+
+validate_fedora_version() {
+    local v="$1"
+    if [[ ! "$v" =~ ^[0-9]+$ ]]; then
+        print_message "ERROR" "Fedora version must be a positive integer (got: '$v')"
+        return 1
+    fi
+    if [ "$v" -lt 30 ] || [ "$v" -gt 99 ]; then
+        print_message "ERROR" "Fedora version must be between 30 and 99 (got: $v)"
+        return 1
+    fi
+    return 0
+}
+
+write_setup_fedora_version() {
+    local v="$1"
+    if ! grep -q '^fedora_version:' "$SETUP_CONFIG"; then
+        print_message "ERROR" "No fedora_version: line found in $SETUP_CONFIG"
+        return 1
+    fi
+    sed -i "s/^fedora_version:.*/fedora_version: ${v}/" "$SETUP_CONFIG"
+}
+
+require_file() {
+    local path="$1"
+    local label="$2"
+    if [ ! -f "$path" ]; then
+        print_message "ERROR" "$label not found: $path"
+        exit 1
+    fi
+}
+
+check_prerequisites() {
+    print_message "INFO" "Checking repository layout and scripts..."
+
+    if [ ! -d "$SETUP_DIR/Kickstarts" ]; then
+        print_message "ERROR" "Setup/Kickstarts not found under $SCRIPT_DIR"
+        exit 1
+    fi
+
+    require_file "$SETUP_CONFIG" "Setup/config.yml"
+    require_file "$PREPARE_BUILD" "Prepare_Fedora_Remix_Build.py"
+    require_file "$PREPARE_WEB" "Prepare_Web_Files.py"
+    require_file "$ENHANCED_SCRIPT" "Enhanced_Remix_Build_Script.sh"
+
+    if [ ! -x "$ENHANCED_SCRIPT" ]; then
+        print_message "WARNING" "Enhanced_Remix_Build_Script.sh is not executable; chmod +x"
+        chmod +x "$ENHANCED_SCRIPT"
+    fi
+
+    if ! command -v sudo >/dev/null 2>&1; then
+        print_message "ERROR" "sudo is required for prepare and build steps"
+        exit 1
+    fi
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        print_message "ERROR" "python3 is required to run prepare scripts"
+        exit 1
+    fi
+
+    print_message "SUCCESS" "Prerequisites OK"
+}
+
+parse_args() {
+    FEDORA_VERSION_ARG=""
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -v|--version)
+                FEDORA_VERSION_ARG="$2"
+                shift 2
+                ;;
+            -k|--kickstart)
+                SELECTED_KICKSTART="$2"
+                shift 2
+                ;;
+            -l|--list)
+                list_kickstarts "$SCRIPT_DIR"
+                exit 0
+                ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                print_message "ERROR" "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+prompt_fedora_version() {
+    local current="$1"
+    local input=""
+
+    echo ""
+    read -r -p "$(echo -e "${BOLD}${WHITE}Fedora remix release to build [${current}]: ${NC}")" input
+    if [ -z "$input" ]; then
+        echo "$current"
+        return
+    fi
+    echo "$input"
+}
+
+main() {
+    parse_args "$@"
+
+    echo ""
+    print_message "HEADER" "${ROCKET} Fedora Remix — Physical (native) build"
+    echo ""
+
+    check_prerequisites
+
+    local current_version
+    current_version=$(get_remix_fedora_version) || exit 1
+
+    local target_version
+    if [ -n "$FEDORA_VERSION_ARG" ]; then
+        target_version="$FEDORA_VERSION_ARG"
+        validate_fedora_version "$target_version" || exit 1
+    else
+        print_message "INFO" "Current fedora_version in Setup/config.yml: ${WHITE}${current_version}${NC}"
+        target_version=$(prompt_fedora_version "$current_version")
+        validate_fedora_version "$target_version" || exit 1
+    fi
+
+    if [ -z "$SELECTED_KICKSTART" ]; then
+        show_kickstart_menu "$SCRIPT_DIR"
+    fi
+
+    if [ ! -f "$SETUP_DIR/Kickstarts/${SELECTED_KICKSTART}.ks" ]; then
+        print_message "ERROR" "Kickstart not found: Setup/Kickstarts/${SELECTED_KICKSTART}.ks"
+        list_kickstarts "$SCRIPT_DIR"
+        exit 1
+    fi
+
+    echo ""
+    echo -e "${BOLD}${CYAN}╔══════════════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BOLD}${CYAN}║${NC} ${WHITE}Build summary (physical)${NC}                                             ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}╠══════════════════════════════════════════════════════════════════════╣${NC}"
+    echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Setup/config.yml${NC}  fedora_version → ${WHITE}${target_version}${NC}                          ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Kickstart${NC}         ${WHITE}${SELECTED_KICKSTART}.ks${NC}                                  ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Work directory${NC}    ${WHITE}${LIVECD_WORKDIR}${NC}                              ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+
+    read -r -p "$(echo -e "${BOLD}${WHITE}Proceed with config update, prepare scripts, and build? [y/N]: ${NC}")" -n 1 -r
+    echo ""
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_message "INFO" "Cancelled."
+        exit 0
+    fi
+
+    write_setup_fedora_version "$target_version"
+    print_message "SUCCESS" "Updated $SETUP_CONFIG (fedora_version: $target_version)"
+
+    print_message "INFO" "Running Prepare_Fedora_Remix_Build.py (sudo python3, cwd: Setup)..."
+    (cd "$SETUP_DIR" && sudo python3 ./Prepare_Fedora_Remix_Build.py)
+
+    print_message "INFO" "Running Prepare_Web_Files.py (sudo python3, cwd: Setup)..."
+    (cd "$SETUP_DIR" && sudo python3 ./Prepare_Web_Files.py)
+
+    if [ ! -d "$LIVECD_WORKDIR" ]; then
+        print_message "ERROR" "Expected directory missing after prepare: $LIVECD_WORKDIR"
+        exit 1
+    fi
+
+    if [ ! -f "$LIVECD_WORKDIR/Enhanced_Remix_Build_Script.sh" ]; then
+        print_message "ERROR" "Enhanced_Remix_Build_Script.sh not found under $LIVECD_WORKDIR"
+        exit 1
+    fi
+
+    print_message "INFO" "Starting livecd build in $LIVECD_WORKDIR (REMIX_KICKSTART=${SELECTED_KICKSTART})..."
+    echo ""
+    (cd "$LIVECD_WORKDIR" && sudo env REMIX_KICKSTART="$SELECTED_KICKSTART" ./Enhanced_Remix_Build_Script.sh)
+    local build_rc=$?
+
+    echo ""
+    if [ "$build_rc" -eq 0 ]; then
+        print_message "SUCCESS" "Build finished successfully (exit $build_rc)."
+    else
+        print_message "ERROR" "Build failed with exit code $build_rc"
+    fi
+    exit "$build_rc"
+}
+
+main "$@"

--- a/Build_Remix_Physical.sh
+++ b/Build_Remix_Physical.sh
@@ -246,7 +246,8 @@ prompt_fedora_version() {
     local current="$1"
     local input=""
 
-    echo ""
+    # Blank line must go to stderr: stdout is captured by $(...) for the return value
+    echo "" >&2
     read -r -p "$(echo -e "${BOLD}${WHITE}Fedora remix release to build [${current}]: ${NC}")" input
     if [ -z "$input" ]; then
         echo "$current"

--- a/Quickstart_Physical.md
+++ b/Quickstart_Physical.md
@@ -1,7 +1,7 @@
 # Fedora Remix Builder - Physical/Virtual Machine Quickstart Guide
 
-**Last Updated:** April 13, 2026  
-**Purpose:** Quick guide to building a custom Fedora Remix ISO on a physical or virtual machine (non-containerized method)
+**Last Updated:** April 27, 2026  
+**Purpose:** Quick guide to building a custom Fedora Remix ISO on a physical or virtual machine (non-containerized method), led by **`Build_Remix_Physical.sh`**
 
 ---
 
@@ -12,7 +12,9 @@ This guide will walk you through building a custom Fedora Remix ISO image direct
 **Build Time:** Approximately 30-45 minutes  
 **Output:** A bootable Fedora Remix ISO file (~7-8 GB)
 
-> **💡 Looking for the containerized method?** See **[Quickstart_Container.md](Quickstart_Container.md)** for building with containers (recommended for most users).
+> **💡 Looking for the containerized method?** See **[Quickstart_Container.md](Quickstart_Container.md)** for building with containers (Podman), or use **[Build_Remix.sh](Build_Remix.sh)** to drive the builder image.
+
+**Recommended (native build):** From the repository root, run **[`Build_Remix_Physical.sh`](Build_Remix_Physical.sh)**. It updates `Setup/config.yml` (`fedora_version`), runs `Setup/Prepare_Fedora_Remix_Build.py` and `Setup/Prepare_Web_Files.py` in the correct order, then runs **[`Setup/Enhanced_Remix_Build_Script.sh`](Setup/Enhanced_Remix_Build_Script.sh)** in `/livecd-creator/FedoraRemix` with the kickstart you choose. Use `./Build_Remix_Physical.sh -h` for options (`-v` release, `-k` kickstart, `-l` list).
 
 ---
 
@@ -51,7 +53,43 @@ If you already have Fedora installed, you can use it as your build system. The s
 
 ---
 
-## Quick Start (7 Steps)
+## Quick start
+
+You can use the **automated script** (fewer steps) or the **manual** path (same operations by hand). Both end with an ISO under `/livecd-creator/FedoraRemix/`.
+
+### Option A: One script (recommended)
+
+After [Step 1](#step-1-install-fedora-remix-if-not-already-installed) through [Step 3](#step-3-clone-the-fedora-remix-repository) (install, sudo, clone repo), run from the **repository root** (the directory that contains `Build_Remix_Physical.sh`):
+
+```bash
+cd /path/to/Fedora_Remix
+chmod +x Build_Remix_Physical.sh   # if needed
+./Build_Remix_Physical.sh
+```
+
+The script will:
+
+1. Ask for the Fedora release (e.g. `43`) and write it to `Setup/config.yml` as `fedora_version`
+2. Offer a **kickstart menu** (e.g. `FedoraRemix`, `FedoraRemixCosmic`); you can also pass `-k` / `-l` (list) on the command line
+3. Run, in order: `sudo python3 Setup/Prepare_Fedora_Remix_Build.py` then `sudo python3 Setup/Prepare_Web_Files.py` (from `Setup/`, as required for paths)
+4. `cd` to `/livecd-creator/FedoraRemix` and run `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh` (the enhanced `livecd-creator` flow with the same UX style as the repo’s other helper scripts)
+
+Useful options:
+
+| Option | Purpose |
+|--------|--------|
+| `-v 43` | Set Fedora version without a prompt |
+| `-k FedoraRemix` | Choose kickstart without the menu |
+| `-l` | List available `FedoraRemix*.ks` base names and exit |
+| `-h` | Help |
+
+**Customize first:** If you need to edit kickstarts before the first run, do [Step 6 (manual)](#step-6-customize-your-remix-optional) *after* `Prepare_Fedora_Remix_Build.py` has populated `/livecd-creator/FedoraRemix/`, or run the script’s prepare steps manually once, edit files, then run the build part only (`cd /livecd-creator/FedoraRemix && sudo env REMIX_KICKSTART=FedoraRemix ./Enhanced_Remix_Build_Script.sh`).
+
+Then skip to [Build output](#build-output) and [Troubleshooting](#troubleshooting).
+
+### Option B: Manual steps (7 steps)
+
+The steps below match what `Build_Remix_Physical.sh` automates, if you prefer to run each command yourself. Prepare order is: **build directory** first, then **web files and patches** (so `/var/www/html` has `kickstart.py` / `fs.py` fixes before `Enhanced_Remix_Build_Script.sh` runs).
 
 ### Step 1: Install Fedora Remix (If Not Already Installed)
 
@@ -119,22 +157,38 @@ cd Fedora_Remix
 
 ### Step 4: Prepare the Build Environment
 
-Run the Python automation scripts to set up the build environment:
+From the `Setup` directory, run the Python scripts in this order (this matches **`Build_Remix_Physical.sh`**):
 
-#### 4a. Prepare Web Files and HTTP Server
+#### 4a. Prepare Fedora Remix build directory
 
 ```bash
 cd Setup
+sudo python3 Prepare_Fedora_Remix_Build.py
+```
+
+**What this does:**
+- Creates `/livecd-creator/FedoraRemix`
+- Copies kickstart files, `Enhanced_Remix_Build_Script.sh`, and related files
+- Copies `Setup/config.yml` to `/livecd-creator/FedoraRemix/config.yml` (used for ISO title / version)
+
+**Expected output (example):**
+```
+Copying ../Remix_Build_Script.sh to /livecd-creator/FedoraRemix/Remix_Build_Script.sh
+Setup complete!
+```
+
+#### 4b. Prepare web files and HTTP server
+
+```bash
 sudo python3 Prepare_Web_Files.py
 ```
 
 **What this does:**
 - Installs Apache HTTP server (`httpd`)
-- Copies necessary files to `/var/www/html/`
-- Sets up local repository assets
-- Configures the web server for the build process
+- Copies files to `/var/www/html/` (including `kickstart.py` and `fs.py` fixes used during the live build)
+- Sets up PXE/boot assets and related web content
 
-**Expected output:**
+**Expected output (example):**
 ```
 Installing packages: httpd
 Running command: dnf install -y httpd
@@ -142,23 +196,7 @@ Running command: dnf install -y httpd
 Setup complete!
 ```
 
-#### 4b. Prepare Fedora Remix Build Directory
-
-```bash
-sudo python3 Prepare_Fedora_Remix_Build.py
-```
-
-**What this does:**
-- Creates `/livecd-creator/FedoraRemix` directory
-- Copies kickstart files to the build directory
-- Copies build scripts
-- Sets up the build environment
-
-**Expected output:**
-```
-Copying ../Remix_Build_Script.sh to /livecd-creator/FedoraRemix/Remix_Build_Script.sh
-Setup complete!
-```
+Always run **4a then 4b** before the enhanced build; the build script looks for patches under `/var/www/html/`.
 
 ### Step 5: Configure Fedora Version
 
@@ -238,19 +276,27 @@ git clone https://github.com/tmichett/bash-git-prompt.git /opt/bash-git-prompt -
 
 ### Step 7: Build the ISO
 
-Navigate to the build directory and run the build script:
+From the build directory, use the **enhanced** script (recommended; same as `Build_Remix_Physical.sh`):
 
 ```bash
 cd /livecd-creator/FedoraRemix
-time sudo ./Remix_Build_Script.sh
+time sudo ./Enhanced_Remix_Build_Script.sh
 ```
+
+For a **variant** other than the default, set `REMIX_KICKSTART` to the kickstart base name (no `.ks`), matching the file in this directory, for example:
+
+```bash
+sudo env REMIX_KICKSTART=FedoraRemixCosmic ./Enhanced_Remix_Build_Script.sh
+```
+
+**Legacy:** `Remix_Build_Script.sh` is the older, simpler script; prefer `Enhanced_Remix_Build_Script.sh` for consistent logging and behavior with the rest of the repo.
 
 **Build Process:**
 1. Reads kickstart configuration
 2. Downloads and installs packages (~15-20 minutes)
 3. Runs post-installation scripts
 4. Creates the ISO image (~5-10 minutes)
-5. ISO saved to `/livecd-creator/FedoraRemix/`
+5. ISO saved in `/livecd-creator/FedoraRemix/` (e.g. `FedoraRemix.iso` or `FedoraRemixCosmic.iso` depending on kickstart)
 
 **Expected output:**
 ```
@@ -266,10 +312,13 @@ user    143m42.195s
 sys     5m11.054s
 ```
 
-**Output Location:**
-```
+**Output Location (default kickstart):**
+
+```text
 /livecd-creator/FedoraRemix/FedoraRemix.iso
 ```
+
+(Variant kickstarts produce a matching name, e.g. `FedoraRemixCosmic.iso`.)
 
 ---
 
@@ -279,11 +328,13 @@ After running the setup scripts, your build environment will look like this:
 
 ```
 /livecd-creator/FedoraRemix/
-├── FedoraRemix.ks              # Main kickstart file
-├── FedoraRemixPackages.ks      # Package list
-├── FedoraRemixRepos.ks         # Repository configuration
-├── Remix_Build_Script.sh       # Build script
-└── FedoraRemix.iso            # Output ISO (after build)
+├── FedoraRemix.ks                 # Main kickstart file
+├── FedoraRemixPackages.ks         # Package list
+├── FedoraRemixRepos.ks            # Repository configuration
+├── config.yml                     # fedora_version (and related) for the enhanced script
+├── Enhanced_Remix_Build_Script.sh   # Recommended build driver
+├── Remix_Build_Script.sh         # Legacy build script
+└── FedoraRemix.iso                # Output ISO (after build; name follows kickstart)
 ```
 
 ---
@@ -569,28 +620,23 @@ To build different desktop environments or configurations:
 3. **Build with new kickstart:**
    ```bash
    cd /livecd-creator/FedoraRemix
-   sudo livecd-creator -c FedoraRemixKDE.ks -f FedoraRemixKDE
+   sudo env REMIX_KICKSTART=FedoraRemixKDE ./Enhanced_Remix_Build_Script.sh
    ```
+   (Or use the same flags / menu with `Build_Remix_Physical.sh -k FedoraRemixKDE`.)
 
 ### Automating Builds
 
-Create a build automation script:
+From the repository root, prefer **`Build_Remix_Physical.sh`** (see [Option A](#option-a-one-script-recommended)) so `fedora_version`, prepare scripts, and `Enhanced_Remix_Build_Script.sh` stay aligned. After `git pull`, run it with `-v` and `-k` to skip version and kickstart prompts; you still confirm once before the script updates config and runs prepare plus build.
 
 ```bash
-#!/bin/bash
-# automated-build.sh
-
 cd ~/Fedora_Remix
 git pull
+./Build_Remix_Physical.sh -v 43 -k FedoraRemix
+```
 
-cd Setup
-sudo python3 Prepare_Web_Files.py
-sudo python3 Prepare_Fedora_Remix_Build.py
+Copy the finished ISO to a web tree if needed:
 
-cd /livecd-creator/FedoraRemix
-time sudo ./Remix_Build_Script.sh
-
-# Copy ISO to distribution directory
+```bash
 cp /livecd-creator/FedoraRemix/*.iso /var/www/html/isos/
 ```
 
@@ -598,20 +644,16 @@ cp /livecd-creator/FedoraRemix/*.iso /var/www/html/isos/
 
 To build for a different Fedora version:
 
-1. **Update configuration:**
-   ```bash
-   sudo vim Setup/config.yml
-   # Change: fedora_version: 44
-   ```
+1. **Set `fedora_version` in `Setup/config.yml`** (or pass `-v 44` to **`Build_Remix_Physical.sh`** when you run it).
 
-2. **Re-run setup scripts:**
+2. **Re-run setup scripts** (or run **`Build_Remix_Physical.sh`** again for a full refresh):
    ```bash
    cd Setup
-   sudo python3 Prepare_Web_Files.py
    sudo python3 Prepare_Fedora_Remix_Build.py
+   sudo python3 Prepare_Web_Files.py
    ```
 
-3. **Build as normal**
+3. **Build as usual** (`Build_Remix_Physical.sh` or `Enhanced_Remix_Build_Script.sh` in `/livecd-creator/FedoraRemix`).
 
 ---
 
@@ -645,6 +687,7 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 
 ### Documentation
 
+- **Asciidoc (PDF / GitHub):** [README_Physical.adoc](README_Physical.adoc) - Physical/virtual install and build narrative (includes *Build_Remix_Physical.sh*)
 - **Container Method:** [Quickstart_Container.md](Quickstart_Container.md) - Containerized build guide
 - **Main README:** [README.md](README.md) - Project overview
 - **Build Fixes:** [LINUX_BUILD_FIX.md](LINUX_BUILD_FIX.md) - Known issues and solutions
@@ -668,24 +711,18 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 
 ## Summary
 
-**Minimum Steps to Build:**
+**Shortest path (recommended):**
 
-1. Install Fedora Remix or use existing Fedora installation
-2. Clone repository: `git clone https://github.com/tmichett/Fedora_Remix.git`
-3. Run setup scripts:
-   - `sudo python3 Setup/Prepare_Web_Files.py`
-   - `sudo python3 Setup/Prepare_Fedora_Remix_Build.py`
-4. Edit `Setup/config.yml` - Set Fedora version
-5. Customize kickstart files (optional):
-   - `/livecd-creator/FedoraRemix/FedoraRemixPackages.ks` - Packages
-   - `/livecd-creator/FedoraRemix/FedoraRemix.ks` - System config
-6. Build: `cd /livecd-creator/FedoraRemix && sudo ./Remix_Build_Script.sh`
-7. Wait 30-45 minutes
-8. Find ISO at `/livecd-creator/FedoraRemix/FedoraRemix.iso`
+1. Install Fedora Remix (or use Fedora) and ensure sudo works
+2. `git clone https://github.com/tmichett/Fedora_Remix.git` and `cd Fedora_Remix`
+3. `./Build_Remix_Physical.sh` (set version, pick kickstart, confirm; script runs prepare + `Enhanced_Remix_Build_Script.sh`)
+4. Find the ISO under `/livecd-creator/FedoraRemix/` (e.g. `FedoraRemix.iso`)
+
+**Manual equivalent:** Edit `Setup/config.yml` (`fedora_version`), run `cd Setup && sudo python3 Prepare_Fedora_Remix_Build.py` then `sudo python3 Prepare_Web_Files.py`, customize kickstarts under `/livecd-creator/FedoraRemix/` if needed, then `cd /livecd-creator/FedoraRemix && sudo ./Enhanced_Remix_Build_Script.sh` (or `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh` for a variant).
 
 **That's it!** You now have a custom Fedora Remix ISO built on your physical or virtual machine.
 
 ---
 
-**Last Updated:** April 13, 2026  
-**Version:** 1.0
+**Last Updated:** April 27, 2026  
+**Version:** 1.1

--- a/README_Physical.adoc
+++ b/README_Physical.adoc
@@ -21,19 +21,21 @@ endif::[]
 
 This quickstart will provide a quick method to download a pre-built Fedora Remix as well as creating your own Fedora Remix Building system. The https://github.com/tmichett/Fedora_Remix has been created with Python automation scripts that will setup a Fedora Remix Building system using the Fedora Remix installed from the liveCD provided (https://drive.google.com/drive/folders/1UAT07AJIrTdMk3ke_QE6S6vz-qn6qGtR). The requirements are relatively simply to build and the system has Fedora Remix customization scripts and self-launching menu to assist with the initial setup. The quickstart and documentation are also available at the following link: https://tmichett.github.io/Fedora_Remix/.
 
+For a Markdown walkthrough that tracks the same flow as *Build_Remix_Physical.sh*, see link:Quickstart_Physical.md[Quickstart_Physical.md] in the repository.
+
 .*Building your own Fedora Remix - Overview*
 
 . Download the Fedora Remix ISO and install locally to hard drive
 .. Setup a local user and ensure it is in the SUDOERS file
 .. Run some the Fedora Remix customize scripts to create SSH keys and SUDO with no password
 . Clone https://github.com/tmichett/Fedora_Remix
-. Run the Python automation scripts with the "sudo" command
-.. Prepare_Web_Files.py
-.. Prepare_Fedora_Remix_Build.py
-. Modify the Kickstart files in */livecd-creator/FedoraRemix*
-.. FedoraRemix.ks - To control various setup components and run commands
-.. FedoraRemixPackages.ks - To control RPM packages that are installed as part of your Remix
-. Run the *Remix_Build_Script.sh*
+. Either run *Build_Remix_Physical.sh* from the repository root (recommended), or run the Python automation scripts manually with `sudo` from the *Setup* directory in this order:
+.. *Prepare_Fedora_Remix_Build.py* (creates `/livecd-creator/FedoraRemix` and copies assets)
+.. *Prepare_Web_Files.py* (HTTPd, web assets, and imgcreate `kickstart.py` / `fs.py` fixes under `/var/www/html/`)
+. Optionally modify the kickstart files in */livecd-creator/FedoraRemix* after the prepare step (or edit under *Setup/Kickstarts/* before building)
+.. *FedoraRemix.ks* - Control various setup components and run commands
+.. *FedoraRemixPackages.ks* - Control RPM packages installed in your Remix
+. Run the enhanced build: *Enhanced_Remix_Build_Script.sh* in `/livecd-creator/FedoraRemix` (invoked for you by *Build_Remix_Physical.sh*). *Remix_Build_Script.sh* remains available as a legacy wrapper
 +
 [WARNING]
 .Error Regarding *kickstart.py*
@@ -97,7 +99,7 @@ After the installation is completed, you will need to reboot your system and per
 ====
 
 
-. Clone the Fedora Remix Repository
+. Clone the Fedora Remix repository
 +
 [source,bash]
 ----
@@ -111,17 +113,29 @@ remote: Enumerating objects: 1949, done
 Resolving deltas: 100% (1042/1042), done.
 ----
 
-. Prepare the Fedora Remix build environment by running the Python scripts from the *Setup* directory as the root user.
+. *Recommended:* from the repository root, run *Build_Remix_Physical.sh*. It prompts for the Fedora release (written to *Setup/config.yml* as `fedora_version`), offers a kickstart choice, then runs *Prepare_Fedora_Remix_Build.py*, *Prepare_Web_Files.py*, and *Enhanced_Remix_Build_Script.sh* in `/livecd-creator/FedoraRemix`. Use `./Build_Remix_Physical.sh -h` for options (`-v`, `-k`, `-l`).
 +
 [source,bash]
-.Create */livecd-creator/FedoraRemix* Assets
+.Run *Build_Remix_Physical.sh* (native / physical build driver)
+----
+travis@localhost-fedoraremix-live [~/Fedora_Remix] | main ✓ |
+$ chmod +x Build_Remix_Physical.sh
+$ ./Build_Remix_Physical.sh
+
+... prompts for version, kickstart, confirmation; then prepare + enhanced build ...
+----
+
+. *Alternative — manual prepare:* run the Python scripts from the *Setup* directory as *root*, in this order (same as *Build_Remix_Physical.sh*):
++
+[source,bash]
+.Create */livecd-creator/FedoraRemix* assets
 ----
 travis@localhost-fedoraremix-live [~/Fedora_Remix/Setup] | (05/09/25 @ 15:57)  | main ✓ |
-$ sudo python Prepare_Fedora_Remix_Build.py
+$ sudo python3 Prepare_Fedora_Remix_Build.py
 
 ... OUTPUT OMITTED ...
 
-Copying ../Remix_Buid_Script.sh to /livecd-creator/FedoraRemix/Remix_Buid_Script.sh
+Copying ../Remix_Build_Script.sh to /livecd-creator/FedoraRemix/Remix_Build_Script.sh
 Setup complete!
 ----
 +
@@ -129,7 +143,7 @@ Setup complete!
 .Create httpd server and repository assets
 ----
 travis@localhost-fedoraremix-live [~/Fedora_Remix/Setup] | (05/09/25 @ 15:59)  | main ✓ |
-$ sudo python Prepare_Web_Files.py
+$ sudo python3 Prepare_Web_Files.py
 Installing packages: httpd
 Running command: dnf install -y httpd
 
@@ -139,8 +153,8 @@ Setup complete!
 ----
 
 
-. Perform System and Package customizations by modifying the *FedoraRemix.ks* kickstart file and the *FedoraRemixPackages.ks* file.
-.. The setup scripts or playbooks created */livecd-creator/FedoraRemix* directory. This is where the kickstart files live that you will modify as well as the directory where the FedoraRemix.iso will reside once built.
+. Perform system and package customizations by modifying the *FedoraRemix.ks* kickstart file and the *FedoraRemixPackages.ks* file (under */livecd-creator/FedoraRemix* after the prepare step). The default *Setup/config.yml* `fedora_version` is updated for you if you use *Build_Remix_Physical.sh*; otherwise set it before or between prepare steps.
+.. The setup scripts create the */livecd-creator/FedoraRemix* directory. That is where you edit kickstarts and where the ISO (e.g. *FedoraRemix.iso*) is written after a successful build.
 +
 [source,bash]
 .FedoraRemix.ks
@@ -187,13 +201,13 @@ podman-machine
 ... OUTPUT OMITTED ...
 ----
 
-. Execute the *Remix_Build_Script.sh* file to kick off the build. Depending on system and Internet connection speed and customizations to the kickstart file, this process could take up to an hour.
+. Execute *Enhanced_Remix_Build_Script.sh* in */livecd-creator/FedoraRemix* to start the build (or rely on the last step of *Build_Remix_Physical.sh*). For a non-default kickstart, set *REMIX_KICKSTART* (e.g. `sudo env REMIX_KICKSTART=FedoraRemixCosmic ./Enhanced_Remix_Build_Script.sh`). Depending on system and network speed and kickstart changes, the process can take on the order of an hour.
 +
 [source,bash]
-.Launching the Script
+.Launch the enhanced build script
 ----
 travis@localhost-fedoraremix-live [/livecd-creator/FedoraRemix] | (05/09/25 @ 16:09)
-$ time ./Remix_Buid_Script.sh
+$ time sudo ./Enhanced_Remix_Build_Script.sh
 /usr/lib/python3.13/site-packages/pykickstart/commands/partition.py:461: KickstartParseWarning: A partition with the mountpoint / has already been defined.
   warnings.warn(_("A partition with the mountpoint %s has already been defined.") % pd.mountpoint, KickstartParseWarning)
 fedora                                           19 MB/s |  35 MB     00:01


### PR DESCRIPTION
## Summary

Adds **`Build_Remix_Physical.sh`** at the repository root: a one-flow driver for **physical / native** Fedora Remix builds (no Podman), with UX aligned with `Verify_Build_Remix.sh` and `Build_Remix.sh` (minus container-only pieces).

## What it does

1. Prompts for the Fedora release (or `-v/--version`), validates it, and updates **`fedora_version`** in **`Setup/config.yml`**.
2. Interactive kickstart selection (or `-k` / `-l` for list), mirroring the kickstart menu pattern from `Build_Remix.sh`.
3. Runs prepare steps from **`Setup/`** (required for relative paths):
   - `sudo python3 ./Prepare_Fedora_Remix_Build.py`
   - `sudo python3 ./Prepare_Web_Files.py`
4. Changes to **`/livecd-creator/FedoraRemix`** and runs:
   - `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh`

## Preconditions

- Run on the host where `/livecd-creator` is used; prepare and build need **sudo**.
- Script resolves paths from its own location (`SCRIPT_DIR`), not only the current working directory.

## How to run

```bash
./Build_Remix_Physical.sh
./Build_Remix_Physical.sh -v 43 -k FedoraRemix
./Build_Remix_Physical.sh -l   # list kickstarts
./Build_Remix_Physical.sh -h   # help
```

## Files

| File | Change |
|------|--------|
| `Build_Remix_Physical.sh` | +341 lines (new) |

---

**Branch:** `feat-physical-build` → `main`