### PR TITLE
FEAT: Preparation for Fedora 44 and PXELinux

### DIFF
--- a/Build_Remix.sh
+++ b/Build_Remix.sh
@@ -22,6 +22,72 @@ show_usage() {
     echo "If no kickstart is specified, you will be prompted to choose."
 }
 
+normalize_yes_no() {
+    local value
+    value=$(echo "$1" | tr '[:upper:]' '[:lower:]' | xargs)
+    case "$value" in
+        y|yes|true|1|on)
+            echo "true"
+            return 0
+            ;;
+        n|no|false|0|off)
+            echo "false"
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+get_include_pxeboot_setting() {
+    local setup_config="$SOURCE_DIR/Setup/config.yml"
+    if [ ! -f "$setup_config" ]; then
+        return 1
+    fi
+
+    local raw
+    raw=$(grep '^include_pxeboot_files:' "$setup_config" | awk '{print $2}' | tr -d '"' || true)
+    if [ -z "$raw" ]; then
+        return 1
+    fi
+
+    normalize_yes_no "$raw"
+}
+
+write_include_pxeboot_setting() {
+    local value="$1"
+    local setup_config="$SOURCE_DIR/Setup/config.yml"
+    if [ ! -f "$setup_config" ]; then
+        return 1
+    fi
+    if grep -q '^include_pxeboot_files:' "$setup_config"; then
+        sed -i "s/^include_pxeboot_files:.*/include_pxeboot_files: ${value}/" "$setup_config"
+    else
+        printf '\ninclude_pxeboot_files: %s\n' "$value" >> "$setup_config"
+    fi
+}
+
+prompt_include_pxeboot() {
+    local default="${1:-true}"
+    local prompt_suffix="[Y/n]"
+    [ "$default" = "false" ] && prompt_suffix="[y/N]"
+    local input=""
+    local normalized=""
+
+    while true; do
+        read -r -p "Include PXEBoot files in web assets? ${prompt_suffix}: " input
+        if [ -z "$input" ]; then
+            echo "$default"
+            return
+        fi
+        normalized=$(normalize_yes_no "$input" || true)
+        if [ -n "$normalized" ]; then
+            echo "$normalized"
+            return
+        fi
+        echo "Please answer yes or no."
+    done
+}
+
 # Function to list available kickstarts
 # Looks in the current directory (GitHub repo) for kickstart source files
 list_kickstarts() {
@@ -204,6 +270,22 @@ if [ -z "$SELECTED_KICKSTART" ]; then
     show_menu "$SOURCE_DIR"
 fi
 
+INCLUDE_PXEBOOT=""
+if [ -n "${REMIX_INCLUDE_PXEBOOT:-}" ]; then
+    INCLUDE_PXEBOOT=$(normalize_yes_no "$REMIX_INCLUDE_PXEBOOT" || true)
+    if [ -z "$INCLUDE_PXEBOOT" ]; then
+        echo "Error: Invalid REMIX_INCLUDE_PXEBOOT value: $REMIX_INCLUDE_PXEBOOT (use true/false)"
+        exit 1
+    fi
+else
+    INCLUDE_PXEBOOT=$(get_include_pxeboot_setting || true)
+    if [ -z "$INCLUDE_PXEBOOT" ]; then
+        INCLUDE_PXEBOOT=$(prompt_include_pxeboot "true")
+    fi
+fi
+
+write_include_pxeboot_setting "$INCLUDE_PXEBOOT" || true
+
 # Validate that the selected kickstart exists (in SOURCE directory)
 if [ ! -f "$SOURCE_DIR/Setup/Kickstarts/${SELECTED_KICKSTART}.ks" ]; then
     echo "Error: Kickstart file not found: ${SELECTED_KICKSTART}.ks"
@@ -222,6 +304,7 @@ echo -e "${MENU_CYAN}╠══════════════════�
 echo -e "${MENU_CYAN}║${MENU_NC}  ${MENU_GREEN}Source:${MENU_NC}       $SOURCE_DIR$(printf '%*s' $((40 - ${#SOURCE_DIR})) '')${MENU_CYAN}║${MENU_NC}"
 echo -e "${MENU_CYAN}║${MENU_NC}  ${MENU_GREEN}Output Dir:${MENU_NC}   $FEDORA_REMIX_LOCATION$(printf '%*s' $((40 - ${#FEDORA_REMIX_LOCATION})) '')${MENU_CYAN}║${MENU_NC}"
 echo -e "${MENU_CYAN}║${MENU_NC}  ${MENU_GREEN}Container:${MENU_NC}    $IMAGE_NAME$(printf '%*s' $((40 - ${#IMAGE_NAME})) '')${MENU_CYAN}║${MENU_NC}"
+echo -e "${MENU_CYAN}║${MENU_NC}  ${MENU_GREEN}PXEBoot:${MENU_NC}      $INCLUDE_PXEBOOT$(printf '%*s' $((40 - ${#INCLUDE_PXEBOOT})) '')${MENU_CYAN}║${MENU_NC}"
 echo -e "${MENU_CYAN}╚═══════════════════════════════════════════════════════════════════╝${MENU_NC}"
 echo ""
 echo -e "${MENU_WHITE}ISO will be created at:${MENU_NC} ${MENU_YELLOW}$FEDORA_REMIX_LOCATION/FedoraRemix/${SELECTED_KICKSTART}.iso${MENU_NC}"
@@ -361,6 +444,7 @@ REMIX_STREAM
 
 RUN_ARGS=("--replace" "--name" "$CONTAINER_NAME" "--systemd=always" "--privileged" "${EXTRA_ARGS[@]}"
   "-e" "REMIX_KICKSTART=$SELECTED_KICKSTART"
+  "-e" "REMIX_INCLUDE_PXEBOOT=$INCLUDE_PXEBOOT"
   "-v" "$SSH_KEY_LOCATION:/root/github_id:ro${VOL_Z}" "-v" "$FEDORA_REMIX_LOCATION:/livecd-creator:rw${VOL_Z}" "-v" "$SOURCE_DIR:/root/workspace:rw${VOL_Z}" "$IMAGE_NAME")
 
 if [ "$ATTACH_MODE" = "1" ]; then

--- a/Build_Remix_Physical.sh
+++ b/Build_Remix_Physical.sh
@@ -32,6 +32,7 @@ readonly PREPARE_WEB="$SETUP_DIR/Prepare_Web_Files.py"
 readonly ENHANCED_SCRIPT="$SETUP_DIR/Enhanced_Remix_Build_Script.sh"
 
 SELECTED_KICKSTART=""
+INCLUDE_PXEBOOT=""
 
 print_message() {
     local level="$1"
@@ -149,6 +150,67 @@ get_remix_fedora_version() {
         return 1
     fi
     echo "$version"
+}
+
+normalize_yes_no() {
+    local value
+    value=$(echo "$1" | tr '[:upper:]' '[:lower:]' | xargs)
+    case "$value" in
+        y|yes|true|1|on)
+            echo "true"
+            return 0
+            ;;
+        n|no|false|0|off)
+            echo "false"
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+get_include_pxeboot_setting() {
+    if [ ! -f "$SETUP_CONFIG" ]; then
+        return 1
+    fi
+
+    local raw
+    raw=$(grep '^include_pxeboot_files:' "$SETUP_CONFIG" | awk '{print $2}' | tr -d '"' || true)
+    if [ -z "$raw" ]; then
+        return 1
+    fi
+
+    normalize_yes_no "$raw"
+}
+
+write_setup_include_pxeboot() {
+    local value="$1"
+    if grep -q '^include_pxeboot_files:' "$SETUP_CONFIG"; then
+        sed -i "s/^include_pxeboot_files:.*/include_pxeboot_files: ${value}/" "$SETUP_CONFIG"
+    else
+        printf '\ninclude_pxeboot_files: %s\n' "$value" >> "$SETUP_CONFIG"
+    fi
+}
+
+prompt_include_pxeboot() {
+    local default="${1:-true}"
+    local prompt_suffix="[Y/n]"
+    [ "$default" = "false" ] && prompt_suffix="[y/N]"
+    local input=""
+    local normalized=""
+
+    while true; do
+        read -r -p "$(echo -e "${BOLD}${WHITE}Include PXEBoot files in web assets? ${prompt_suffix}: ${NC}")" input
+        if [ -z "$input" ]; then
+            echo "$default"
+            return
+        fi
+        normalized=$(normalize_yes_no "$input" || true)
+        if [ -n "$normalized" ]; then
+            echo "$normalized"
+            return
+        fi
+        print_message "WARNING" "Please answer yes or no."
+    done
 }
 
 validate_fedora_version() {
@@ -278,6 +340,23 @@ main() {
         validate_fedora_version "$target_version" || exit 1
     fi
 
+    local include_pxeboot_setting
+    if [ -n "${REMIX_INCLUDE_PXEBOOT:-}" ]; then
+        include_pxeboot_setting=$(normalize_yes_no "${REMIX_INCLUDE_PXEBOOT}" || true)
+        if [ -z "$include_pxeboot_setting" ]; then
+            print_message "ERROR" "Invalid REMIX_INCLUDE_PXEBOOT value: ${REMIX_INCLUDE_PXEBOOT} (use true/false)"
+            exit 1
+        fi
+    else
+        include_pxeboot_setting=$(get_include_pxeboot_setting || true)
+        if [ -z "$include_pxeboot_setting" ]; then
+            print_message "INFO" "Setup/config.yml has no include_pxeboot_files setting."
+            include_pxeboot_setting=$(prompt_include_pxeboot "true")
+        fi
+    fi
+
+    INCLUDE_PXEBOOT="$include_pxeboot_setting"
+
     if [ -z "$SELECTED_KICKSTART" ]; then
         show_kickstart_menu "$SCRIPT_DIR"
     fi
@@ -294,6 +373,7 @@ main() {
     echo -e "${BOLD}${CYAN}╠══════════════════════════════════════════════════════════════════════╣${NC}"
     echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Setup/config.yml${NC}  fedora_version → ${WHITE}${target_version}${NC}                          ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Kickstart${NC}         ${WHITE}${SELECTED_KICKSTART}.ks${NC}                                  ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}PXEBoot files${NC}     ${WHITE}${INCLUDE_PXEBOOT}${NC}                                            ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Work directory${NC}    ${WHITE}${LIVECD_WORKDIR}${NC}                              ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════════════╝${NC}"
     echo ""
@@ -308,12 +388,14 @@ main() {
 
     write_setup_fedora_version "$target_version"
     print_message "SUCCESS" "Updated $SETUP_CONFIG (fedora_version: $target_version)"
+    write_setup_include_pxeboot "$INCLUDE_PXEBOOT"
+    print_message "SUCCESS" "Updated $SETUP_CONFIG (include_pxeboot_files: $INCLUDE_PXEBOOT)"
 
     print_message "INFO" "Running Prepare_Fedora_Remix_Build.py (sudo python3, cwd: Setup)..."
     (cd "$SETUP_DIR" && sudo python3 ./Prepare_Fedora_Remix_Build.py)
 
     print_message "INFO" "Running Prepare_Web_Files.py (sudo python3, cwd: Setup)..."
-    (cd "$SETUP_DIR" && sudo python3 ./Prepare_Web_Files.py)
+    (cd "$SETUP_DIR" && sudo env REMIX_INCLUDE_PXEBOOT="$INCLUDE_PXEBOOT" python3 ./Prepare_Web_Files.py)
 
     if [ ! -d "$LIVECD_WORKDIR" ]; then
         print_message "ERROR" "Expected directory missing after prepare: $LIVECD_WORKDIR"
@@ -325,9 +407,9 @@ main() {
         exit 1
     fi
 
-    print_message "INFO" "Starting livecd build in $LIVECD_WORKDIR (REMIX_KICKSTART=${SELECTED_KICKSTART})..."
+    print_message "INFO" "Starting livecd build in $LIVECD_WORKDIR (REMIX_KICKSTART=${SELECTED_KICKSTART}, REMIX_INCLUDE_PXEBOOT=${INCLUDE_PXEBOOT})..."
     echo ""
-    (cd "$LIVECD_WORKDIR" && sudo env REMIX_KICKSTART="$SELECTED_KICKSTART" ./Enhanced_Remix_Build_Script.sh)
+    (cd "$LIVECD_WORKDIR" && sudo env REMIX_KICKSTART="$SELECTED_KICKSTART" REMIX_INCLUDE_PXEBOOT="$INCLUDE_PXEBOOT" ./Enhanced_Remix_Build_Script.sh)
     local build_rc=$?
 
     echo ""

--- a/Quickstart_Container.adoc
+++ b/Quickstart_Container.adoc
@@ -4,7 +4,7 @@
 :icons: font
 :source-highlighter: rouge
 :last-update-label!:
-:docdate: April 13, 2026
+:docdate: April 28, 2026
 
 [.lead]
 Quick guide to building a custom Fedora Remix ISO using the containerized build system.
@@ -98,9 +98,9 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ----
 
-=== Step 2: Configure Container Properties
+=== Step 2: Container-specific settings in `config.yml`
 
-Edit the main configuration file to set up the build environment:
+Edit the main configuration file for paths and registry that the container build uses (SSH key, ISO output directory, GitHub Container Registry owner). You can set `Fedora_Version` here or rely on *Update_Remix_Config.sh* (next step) to align `Fedora_Version` and *Setup/config.yml* for you.
 
 [source,bash]
 ----
@@ -111,7 +111,7 @@ vim config.yml
 [source,yaml]
 ----
 Container_Properties:
-  Fedora_Version: "43"                              # Fedora version for container
+  Fedora_Version: "43"                              # Prefer *Update_Remix_Config.sh* (Step 3) to keep both configs in sync
   SSH_Key_Location: "~/.ssh/github_id"              # Your SSH key location
   Fedora_Remix_Location: "/home/travis/Remix_Builder"  # Output directory
   GitHub_Registry_Owner: "tmichett"                 # Container registry owner
@@ -124,7 +124,7 @@ Container_Properties:
 |Option |Description
 
 |`Fedora_Version`
-|Must match the Fedora version you want to build (e.g., "43")
+|String form of the Fedora release used in the builder image tag (`ghcr.io/.../fedora-remix-builder:{version}`). Prefer setting it with *Update_Remix_Config.sh* so it matches *Setup/config.yml*.
 
 |`SSH_Key_Location`
 |Path to your SSH key (used for git operations in container)
@@ -146,35 +146,41 @@ Container_Properties:
   GitHub_Registry_Owner: "tmichett"
 ----
 
-=== Step 3: Configure Remix Build Settings
+=== Step 3: Fedora release and PXE (*Update_Remix_Config.sh* — recommended)
 
-Edit the Setup configuration file:
+Instead of manually editing `Fedora_Version` in `config.yml` and `fedora_version` / `include_pxeboot_files` in *Setup/config.yml*, run from the repository root:
+
+[source,bash]
+----
+chmod +x Update_Remix_Config.sh
+./Update_Remix_Config.sh
+----
+
+The script prompts for the Fedora release and whether to download **PXE Linux** boot artifacts into the web prepare step (*include_pxeboot_files*). When *true*, container prepare stages `vmlinuz` and `initrd.img` for optional **network (PXE/HTTP) boot** tooling on the Remix. If you answer *no*, PXE assets are skipped.
+
+[IMPORTANT]
+====
+For some **older**, EOL, or **very new** Fedora versions, those images may be **unavailable** or **not** at the paths *Prepare_Web_Files.py* expects—the prepare or build can **fail**. If you are **not** using PXE/Linux network boot from this workflow, answer *no* (`include_pxeboot_files: false`).
+====
+
+[WARNING]
+====
+The `fedora_version` in *Setup/config.yml* *MUST match* `Fedora_Version` in the root `config.yml`. *Update_Remix_Config.sh* updates both together to avoid drift.
+====
+
+.Manual YAML (only if you did *not* run *Update_Remix_Config.sh*)
+Edit *Setup/config.yml* so `fedora_version` matches `Fedora_Version`, and set `include_pxeboot_files` explicitly.
 
 [source,bash]
 ----
 vim Setup/config.yml
 ----
 
-.Required Settings
-[source,yaml]
-----
-# Fedora version to use for downloading boot files
-fedora_version: 43    # MUST match Fedora_Version in config.yml
-
-# Web root directory where files will be served
-web_root: "/var/www/html"
-----
-
-[WARNING]
-====
-The `fedora_version` here *MUST match* the `Fedora_Version` in the main `config.yml` file!
-====
-
-.Example
 [source,yaml]
 ----
 fedora_version: 43
 web_root: "/var/www/html"
+include_pxeboot_files: false
 ----
 
 === Step 4: Verify Configuration (Recommended)
@@ -445,6 +451,9 @@ fedora_version: 43
 
 # Web root directory where files will be served
 web_root: "/var/www/html"
+
+# Download vmlinuz/initrd for PXE when true (see Update_Remix_Config.sh / Quick Start)
+include_pxeboot_files: false
 ----
 
 == Troubleshooting
@@ -459,17 +468,14 @@ web_root: "/var/www/html"
 ----
 
 .Solution
-Update both config files to use the same version:
+Run `./Update_Remix_Config.sh` so `Fedora_Version` and `fedora_version` match, or edit both files to the same release:
 
 [source,bash]
 ----
-# Edit main config
+./Update_Remix_Config.sh
+# or
 vim config.yml
-# Set: Fedora_Version: "43"
-
-# Edit setup config
 vim Setup/config.yml
-# Set: fedora_version: 43
 ----
 
 === Container Image Not Found
@@ -627,15 +633,18 @@ Replace `/dev/sdX` with your USB device.
 
 To build for a different Fedora version:
 
-. Update both config files:
+. Run `./Update_Remix_Config.sh` and enter the new release (or update `Fedora_Version` and `fedora_version` together):
 +
 [source,bash]
 ----
-# config.yml
-Fedora_Version: "44"
-
-# Setup/config.yml
-fedora_version: 44
+./Update_Remix_Config.sh
+----
++
+[source,bash]
+----
+# or edit both files manually
+# config.yml  -> Fedora_Version: "44"
+# Setup/config.yml -> fedora_version: 44
 ----
 
 . Verify the container image exists:
@@ -685,6 +694,8 @@ done
 
 === Documentation
 
+* *Physical/quickstart (ADOC/PDF):* link:README_Physical.adoc[README_Physical.adoc]
+* *Config helper:* link:Update_Remix_Config.sh[Update_Remix_Config.sh] — align `Fedora_Version`, `fedora_version`, PXE (`include_pxeboot_files`)
 * *Main README:* link:README.md[README.md] - Project overview
 * *Build Fixes:* link:LINUX_BUILD_FIX.md[LINUX_BUILD_FIX.md] - Known issues and solutions
 * *SELinux Fix:* link:SELINUX_RELABEL_FIX.md[SELINUX_RELABEL_FIX.md] - SELinux relabeling fix details
@@ -709,9 +720,9 @@ done
 .Minimum Steps to Build
 
 . Clone repository: `git clone https://github.com/tmichett/Fedora_Remix.git`
-. Edit `config.yml` - Set container properties
-. Edit `Setup/config.yml` - Set remix version (must match!)
-. Run `./Verify_Build_Remix.sh` - Verify and build
+. Edit root `config.yml` — SSH key, ISO output directory, registry owner
+. Run `./Update_Remix_Config.sh` — Fedora release plus PXE/Linux assets (**no** recommended unless you need PXE)
+. Run `./Verify_Build_Remix.sh` — Verify and build
 . Wait 30-45 minutes
 . Find ISO at `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
 
@@ -724,7 +735,5 @@ done
 [.text-center]
 *That's it!* You now have a custom Fedora Remix ISO ready to use.
 
-'''
-
 [.text-center]
-_Last Updated: April 13, 2026 | Version: 1.0_
+_Last Updated: April 28, 2026 | Version: 1.1_

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -1,6 +1,6 @@
 # Fedora Remix Builder - Container Quickstart Guide
 
-**Last Updated:** April 22, 2026  
+**Last Updated:** April 28, 2026  
 **Purpose:** Quick guide to building a custom Fedora Remix ISO using the containerized build system
 
 ---
@@ -106,9 +106,9 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ```
 
-### Step 2: Configure Container Properties
+### Step 2: Container-specific settings (`config.yml`)
 
-Edit the main configuration file to set up the build environment:
+Edit the root configuration for paths the builder container needs: **SSH key**, **ISO/output directory**, and **GitHub Container Registry owner**. You can set **`Fedora_Version`** here manually, or rely on **`Update_Remix_Config.sh`** (Step 3) to align **`Fedora_Version`** and **`Setup/config.yml`** for you.
 
 ```bash
 vim config.yml
@@ -118,7 +118,7 @@ vim config.yml
 
 ```yaml
 Container_Properties:
-  Fedora_Version: "43"                              # Fedora version for container
+  Fedora_Version: "43"                              # Prefer Update_Remix_Config.sh (Step 3) to keep both YAML files in sync
   SSH_Key_Location: "~/.ssh/github_id"              # Your SSH key location
   Fedora_Remix_Location: "/home/travis/Remix_Builder"  # Output directory
   GitHub_Registry_Owner: "tmichett"                 # Container registry owner
@@ -126,7 +126,7 @@ Container_Properties:
 
 **Key Configuration Options:**
 
-- **`Fedora_Version`**: Must match the Fedora version you want to build (e.g., "43")
+- **`Fedora_Version`**: Fedora release embedded in `ghcr.io/.../fedora-remix-builder:{version}`; prefer setting alongside remix settings via **`Update_Remix_Config.sh`** so nothing drifts out of sync.
 - **`SSH_Key_Location`**: Path to your SSH key (used for git operations in container)
 - **`Fedora_Remix_Location`**: Where the ISO and build artifacts will be saved
 - **`GitHub_Registry_Owner`**: GitHub username/org that hosts the container image
@@ -141,30 +141,31 @@ Container_Properties:
   GitHub_Registry_Owner: "tmichett"
 ```
 
-### Step 3: Configure Remix Build Settings
+### Step 3: Fedora release and PXE (`Update_Remix_Config.sh` — recommended)
 
-Edit the Setup configuration file:
+Instead of manually editing **`Fedora_Version`** in `config.yml` and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`**, run from the repository root:
+
+```bash
+chmod +x Update_Remix_Config.sh   # once
+./Update_Remix_Config.sh
+```
+
+The script asks for the Fedora release and whether to download **PXE Linux** boot images (`vmlinuz`, `initrd.img`) for the web prepare step. When enabled, that supports optionally using the Remix build environment for **network (PXE/HTTP) boot** content. If you answer **no**, PXE assets are skipped (`include_pxeboot_files: false`).
+
+> **Important:** For some **older** (including EOL) or **very new** Fedora versions, those images may be **unavailable** or **not** at the standard paths **`Prepare_Web_Files.py`** uses—prepare or build can **fail**. If you are **not** using PXE/Linux network boot, answer **no**.
+
+**⚠️ CRITICAL:** `fedora_version` in **`Setup/config.yml`** **must match** `Fedora_Version` in **`config.yml`**. **`Update_Remix_Config.sh`** updates both together.
+
+**Manual alternative (skip if you used the script):** edit `Setup/config.yml` so everything lines up:
 
 ```bash
 vim Setup/config.yml
 ```
 
-**Required Settings:**
-
-```yaml
-# Fedora version to use for downloading boot files
-fedora_version: 43    # MUST match Fedora_Version in config.yml
-
-# Web root directory where files will be served
-web_root: "/var/www/html"
-```
-
-**⚠️ CRITICAL:** The `fedora_version` here **MUST match** the `Fedora_Version` in the main `config.yml` file!
-
-**Example:**
 ```yaml
 fedora_version: 43
 web_root: "/var/www/html"
+include_pxeboot_files: false
 ```
 
 ### Step 4: Verify Configuration (Recommended)
@@ -438,6 +439,9 @@ fedora_version: 43
 
 # Web root directory where files will be served
 web_root: "/var/www/html"
+
+# PXE/Linux boot images — prefer ./Update_Remix_Config.sh for this toggle
+include_pxeboot_files: false
 ```
 
 ---
@@ -454,15 +458,13 @@ web_root: "/var/www/html"
 ```
 
 **Solution:**
-Update both config files to use the same version:
+Run `./Update_Remix_Config.sh` and enter matching values, or edit both files to the same release:
 ```bash
-# Edit main config
-vim config.yml
-# Set: Fedora_Version: "43"
+./Update_Remix_Config.sh
 
-# Edit setup config
+# manual alternative
+vim config.yml
 vim Setup/config.yml
-# Set: fedora_version: 43
 ```
 
 ### Container Image Not Found
@@ -612,13 +614,14 @@ When you run `./Build_Remix.sh` in the default mode, your terminal shows the **s
 
 To build for a different Fedora version:
 
-1. Update both config files:
+1. Run **`./Update_Remix_Config.sh`** and enter the new release—or edit **`Fedora_Version`** and **`fedora_version`** together:
    ```bash
-   # config.yml
-   Fedora_Version: "44"
-   
-   # Setup/config.yml
-   fedora_version: 44
+   ./Update_Remix_Config.sh
+   ```
+   ```bash
+   # manual alternative
+   # config.yml -> Fedora_Version: "44"
+   # Setup/config.yml -> fedora_version: 44
    ```
 
 2. Verify the container image exists:
@@ -666,6 +669,7 @@ done
 
 ### Documentation
 
+- **Physical/virtual quickstart (Asciidoctor/PDF):** `README_Physical.adoc`
 - **Main README:** `README.md` - Project overview
 - **Build Fixes:** `LINUX_BUILD_FIX.md` - Known issues and solutions
 - **SELinux Fix:** `SELINUX_RELABEL_FIX.md` - SELinux relabeling fix details
@@ -692,10 +696,10 @@ done
 **Minimum Steps to Build:**
 
 1. Clone repository: `git clone https://github.com/tmichett/Fedora_Remix.git`
-2. Edit `config.yml` - Set container properties
-3. Edit `Setup/config.yml` - Set remix version (must match!)
-4. Run `./Verify_Build_Remix.sh` - Verify and build
-5. Wait 30-45 minutes (build log streams in the same terminal; when the follow step ends, run `podman stop remix-builder` if you are done with the container)
+2. Edit **`config.yml`** — SSH key path, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
+3. Run **`./Update_Remix_Config.sh`** — Fedora release and PXE option (**no** recommended unless you need PXE)
+4. Run `./Verify_Build_Remix.sh` — Verify and build
+5. Wait 30–45 minutes (build log streams in the same terminal; when the follow step ends, run `podman stop remix-builder` if you are done with the container)
 6. Find ISO at `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
 
 **Optional Customization:**
@@ -708,5 +712,5 @@ done
 
 ---
 
-**Last Updated:** April 22, 2026  
-**Version:** 1.1
+**Last Updated:** April 28, 2026  
+**Version:** 1.2

--- a/Quickstart_Physical.md
+++ b/Quickstart_Physical.md
@@ -1,6 +1,6 @@
 # Fedora Remix Builder - Physical/Virtual Machine Quickstart Guide
 
-**Last Updated:** April 27, 2026  
+**Last Updated:** April 28, 2026  
 **Purpose:** Quick guide to building a custom Fedora Remix ISO on a physical or virtual machine (non-containerized method), led by **`Build_Remix_Physical.sh`**
 
 ---
@@ -14,7 +14,9 @@ This guide will walk you through building a custom Fedora Remix ISO image direct
 
 > **💡 Looking for the containerized method?** See **[Quickstart_Container.md](Quickstart_Container.md)** for building with containers (Podman), or use **[Build_Remix.sh](Build_Remix.sh)** to drive the builder image.
 
-**Recommended (native build):** From the repository root, run **[`Build_Remix_Physical.sh`](Build_Remix_Physical.sh)**. It updates `Setup/config.yml` (`fedora_version`), runs `Setup/Prepare_Fedora_Remix_Build.py` and `Setup/Prepare_Web_Files.py` in the correct order, then runs **[`Setup/Enhanced_Remix_Build_Script.sh`](Setup/Enhanced_Remix_Build_Script.sh)** in `/livecd-creator/FedoraRemix` with the kickstart you choose. Use `./Build_Remix_Physical.sh -h` for options (`-v` release, `-k` kickstart, `-l` list).
+**Configure first (recommended):** **[`Update_Remix_Config.sh`](Update_Remix_Config.sh)** interactively sets Fedora release and whether to stage **PXE Linux** boot artifacts (`vmlinuz`, `initrd.img` in the web tree). It updates the root **`config.yml`** (`Fedora_Version`), **`Setup/config.yml`** (`fedora_version`, `include_pxeboot_files`), replacing most manual YAML edits. See [Step 4](#step-4-fedora-release-and-pxe-update_remix_configsh) for PXE caveats on old or very new Fedora versions.
+
+**Recommended (native build):** From the repository root, run **[`Build_Remix_Physical.sh`](Build_Remix_Physical.sh)**. It updates `Setup/config.yml` (`fedora_version`), runs `Setup/Prepare_Fedora_Remix_Build.py` and `Setup/Prepare_Web_Files.py` in the correct order, then runs **[`Setup/Enhanced_Remix_Build_Script.sh`](Setup/Enhanced_Remix_Build_Script.sh)** in `/livecd-creator/FedoraRemix` with the kickstart you choose. Use `./Build_Remix_Physical.sh -h` for options (`-v` release, `-k` kickstart, `-l` list). You can run **`Update_Remix_Config.sh`** first so version and PXE settings are already correct before this script prompts.
 
 ---
 
@@ -69,7 +71,7 @@ chmod +x Build_Remix_Physical.sh   # if needed
 
 The script will:
 
-1. Ask for the Fedora release (e.g. `43`) and write it to `Setup/config.yml` as `fedora_version`
+1. Ask for the Fedora release (e.g. `43`) and write it to `Setup/config.yml` as `fedora_version`—unless you already set version and PXE options with **`Update_Remix_Config.sh`**
 2. Offer a **kickstart menu** (e.g. `FedoraRemix`, `FedoraRemixCosmic`); you can also pass `-k` / `-l` (list) on the command line
 3. Run, in order: `sudo python3 Setup/Prepare_Fedora_Remix_Build.py` then `sudo python3 Setup/Prepare_Web_Files.py` (from `Setup/`, as required for paths)
 4. `cd` to `/livecd-creator/FedoraRemix` and run `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh` (the enhanced `livecd-creator` flow with the same UX style as the repo’s other helper scripts)
@@ -87,9 +89,9 @@ Useful options:
 
 Then skip to [Build output](#build-output) and [Troubleshooting](#troubleshooting).
 
-### Option B: Manual steps (7 steps)
+### Option B: Manual steps (8 steps)
 
-The steps below match what `Build_Remix_Physical.sh` automates, if you prefer to run each command yourself. Prepare order is: **build directory** first, then **web files and patches** (so `/var/www/html` has `kickstart.py` / `fs.py` fixes before `Enhanced_Remix_Build_Script.sh` runs).
+The steps below match what `Build_Remix_Physical.sh` automates, if you prefer to run each command yourself. After [Step 4](#step-4-fedora-release-and-pxe-update_remix_configsh), prepare order is: **build directory** first, then **web files and patches** (so `/var/www/html` has `kickstart.py` / `fs.py` fixes before `Enhanced_Remix_Build_Script.sh` runs).
 
 ### Step 1: Install Fedora Remix (If Not Already Installed)
 
@@ -155,11 +157,37 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ```
 
-### Step 4: Prepare the Build Environment
+### Step 4: Fedora release and PXE (`Update_Remix_Config.sh`)
+
+From the **repository root**, run the helper script **instead of manually editing** both config files:
+
+```bash
+chmod +x Update_Remix_Config.sh   # once
+./Update_Remix_Config.sh
+```
+
+**What it configures**
+
+- Root **`config.yml`**: `Container_Properties.Fedora_Version` (keeps the tree aligned if you use container tools later or share the clone).
+- **`Setup/config.yml`**: `fedora_version` (must match `Fedora_Version`), and `include_pxeboot_files`.
+
+When **`include_pxeboot_files`** is **true**, **`Prepare_Web_Files.py`** downloads **PXE/Linux** installer images (`vmlinuz`, `initrd.img`) into the web tree so you can optionally use this host with **httpd** as part of a **network (PXE)** install setup for your Remix. If you answer **no**, the preparer skips those downloads (`include_pxeboot_files: false`).
+
+> **Important:** For some **older** (including EOL) or **very new** Fedora spins, those artifacts may be **missing** or not at the **standard mirror paths** `Prepare_Web_Files.py` uses; enabling PXE assets can cause **prepare or build failure**. If you are **not** using PXE/Linux network boot from this machine, choose **no** and keep `include_pxeboot_files: false`.
+
+**Manual alternative:** edit `sudo vim config.yml` and `sudo vim Setup/config.yml` so `Fedora_Version` and `fedora_version` agree, and set `include_pxeboot_files` explicitly, for example:
+
+```yaml
+fedora_version: 43
+web_root: "/var/www/html"
+include_pxeboot_files: false
+```
+
+### Step 5: Prepare the Build Environment
 
 From the `Setup` directory, run the Python scripts in this order (this matches **`Build_Remix_Physical.sh`**):
 
-#### 4a. Prepare Fedora Remix build directory
+#### 5a. Prepare Fedora Remix build directory
 
 ```bash
 cd Setup
@@ -177,7 +205,7 @@ Copying ../Remix_Build_Script.sh to /livecd-creator/FedoraRemix/Remix_Build_Scri
 Setup complete!
 ```
 
-#### 4b. Prepare web files and HTTP server
+#### 5b. Prepare web files and HTTP server
 
 ```bash
 sudo python3 Prepare_Web_Files.py
@@ -186,7 +214,7 @@ sudo python3 Prepare_Web_Files.py
 **What this does:**
 - Installs Apache HTTP server (`httpd`)
 - Copies files to `/var/www/html/` (including `kickstart.py` and `fs.py` fixes used during the live build)
-- Sets up PXE/boot assets and related web content
+- If `include_pxeboot_files` is true in `Setup/config.yml`, downloads **PXE/Linux** `vmlinuz` and `initrd.img` for the chosen `fedora_version`; otherwise skips those downloads
 
 **Expected output (example):**
 ```
@@ -196,24 +224,7 @@ Running command: dnf install -y httpd
 Setup complete!
 ```
 
-Always run **4a then 4b** before the enhanced build; the build script looks for patches under `/var/www/html/`.
-
-### Step 5: Configure Fedora Version
-
-Edit the configuration file to set your Fedora version:
-
-```bash
-sudo vim Setup/config.yml
-```
-
-**Set the Fedora version:**
-```yaml
-# Fedora version to use for downloading boot files
-fedora_version: 43
-
-# Web root directory where files will be served
-web_root: "/var/www/html"
-```
+Always run **5a then 5b** before the enhanced build; the build script looks for patches under `/var/www/html/`.
 
 ### Step 6: Customize Your Remix (Optional)
 
@@ -644,7 +655,7 @@ cp /livecd-creator/FedoraRemix/*.iso /var/www/html/isos/
 
 To build for a different Fedora version:
 
-1. **Set `fedora_version` in `Setup/config.yml`** (or pass `-v 44` to **`Build_Remix_Physical.sh`** when you run it).
+1. **Run `./Update_Remix_Config.sh`** or **set `fedora_version` / `Fedora_Version` in YAML** (or pass `-v 44` to **`Build_Remix_Physical.sh`** when you run it). If you use PXE assets, check that `include_pxeboot_files` still makes sense for that release.
 
 2. **Re-run setup scripts** (or run **`Build_Remix_Physical.sh`** again for a full refresh):
    ```bash
@@ -687,7 +698,7 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 
 ### Documentation
 
-- **Asciidoc (PDF / GitHub):** [README_Physical.adoc](README_Physical.adoc) - Physical/virtual install and build narrative (includes *Build_Remix_Physical.sh*)
+- **Asciidoc (PDF / GitHub):** [README_Physical.adoc](README_Physical.adoc) - Physical/virtual install and build narrative (includes *Build_Remix_Physical.sh* and *[Update_Remix_Config.sh](Update_Remix_Config.sh)*)
 - **Container Method:** [Quickstart_Container.md](Quickstart_Container.md) - Containerized build guide
 - **Main README:** [README.md](README.md) - Project overview
 - **Build Fixes:** [LINUX_BUILD_FIX.md](LINUX_BUILD_FIX.md) - Known issues and solutions
@@ -715,14 +726,15 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 
 1. Install Fedora Remix (or use Fedora) and ensure sudo works
 2. `git clone https://github.com/tmichett/Fedora_Remix.git` and `cd Fedora_Remix`
-3. `./Build_Remix_Physical.sh` (set version, pick kickstart, confirm; script runs prepare + `Enhanced_Remix_Build_Script.sh`)
-4. Find the ISO under `/livecd-creator/FedoraRemix/` (e.g. `FedoraRemix.iso`)
+3. **`./Update_Remix_Config.sh`** to set Fedora release and PXE option (recommended; use **no** for PXE if you only need a local ISO)
+4. `./Build_Remix_Physical.sh` (set version if not already done, pick kickstart, confirm; script runs prepare + `Enhanced_Remix_Build_Script.sh`)
+5. Find the ISO under `/livecd-creator/FedoraRemix/` (e.g. `FedoraRemix.iso`)
 
-**Manual equivalent:** Edit `Setup/config.yml` (`fedora_version`), run `cd Setup && sudo python3 Prepare_Fedora_Remix_Build.py` then `sudo python3 Prepare_Web_Files.py`, customize kickstarts under `/livecd-creator/FedoraRemix/` if needed, then `cd /livecd-creator/FedoraRemix && sudo ./Enhanced_Remix_Build_Script.sh` (or `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh` for a variant).
+**Manual equivalent:** Run **`Update_Remix_Config.sh`** (or edit root `config.yml` and `Setup/config.yml` manually), then run `cd Setup && sudo python3 Prepare_Fedora_Remix_Build.py` then `sudo python3 Prepare_Web_Files.py`, customize kickstarts under `/livecd-creator/FedoraRemix/` if needed, then `cd /livecd-creator/FedoraRemix && sudo ./Enhanced_Remix_Build_Script.sh` (or `sudo env REMIX_KICKSTART=… ./Enhanced_Remix_Build_Script.sh` for a variant).
 
 **That's it!** You now have a custom Fedora Remix ISO built on your physical or virtual machine.
 
 ---
 
-**Last Updated:** April 27, 2026  
-**Version:** 1.1
+**Last Updated:** April 28, 2026  
+**Version:** 1.2

--- a/README_Physical.adoc
+++ b/README_Physical.adoc
@@ -23,12 +23,30 @@ This quickstart will provide a quick method to download a pre-built Fedora Remix
 
 For a Markdown walkthrough that tracks the same flow as *Build_Remix_Physical.sh*, see link:Quickstart_Physical.md[Quickstart_Physical.md] in the repository.
 
+== Fedora release and PXE (*Update_Remix_Config.sh*)
+
+After you clone the repository, run *Update_Remix_Config.sh* from the repository root (recommended) instead of manually editing *config.yml* and *Setup/config.yml*.
+
+[source,bash]
+----
+chmod +x Update_Remix_Config.sh
+./Update_Remix_Config.sh
+----
+
+The script asks for the Fedora release and whether to download **PXE Linux** boot images for the web tree. It updates *config.yml* (*Container_Properties.Fedora_Version*), *Setup/config.yml* *fedora_version*, and *include_pxeboot_files*. When *include_pxeboot_files* is *true*, *Prepare_Web_Files.py* fetches `vmlinuz` and `initrd.img` so you can optionally use the build host (HTTPd) as part of a **PXE** / network-install layout for your Fedora Remix.
+
+[IMPORTANT]
+====
+For some **older** releases, EOL composes, or **very new** Fedora versions, those kernel and initrd artifacts may be **missing** or not at the expected mirror paths; including PXE assets can make *Prepare_Web_Files.py* or later steps **fail**. If you are **not** planning to serve PXE/network-boot content from this system, answer *no* and keep `include_pxeboot_files: false`.
+====
+
 .*Building your own Fedora Remix - Overview*
 
 . Download the Fedora Remix ISO and install locally to hard drive
 .. Setup a local user and ensure it is in the SUDOERS file
 .. Run some the Fedora Remix customize scripts to create SSH keys and SUDO with no password
 . Clone https://github.com/tmichett/Fedora_Remix
+. Run *Update_Remix_Config.sh* from the repository root (recommended) to align *Fedora_Version*, *fedora_version*, and PXE-related *include_pxeboot_files*; or set those values by hand in *config.yml* and *Setup/config.yml*
 . Either run *Build_Remix_Physical.sh* from the repository root (recommended), or run the Python automation scripts manually with `sudo` from the *Setup* directory in this order:
 .. *Prepare_Fedora_Remix_Build.py* (creates `/livecd-creator/FedoraRemix` and copies assets)
 .. *Prepare_Web_Files.py* (HTTPd, web assets, and imgcreate `kickstart.py` / `fs.py` fixes under `/var/www/html/`)
@@ -113,7 +131,7 @@ remote: Enumerating objects: 1949, done
 Resolving deltas: 100% (1042/1042), done.
 ----
 
-. *Recommended:* from the repository root, run *Build_Remix_Physical.sh*. It prompts for the Fedora release (written to *Setup/config.yml* as `fedora_version`), offers a kickstart choice, then runs *Prepare_Fedora_Remix_Build.py*, *Prepare_Web_Files.py*, and *Enhanced_Remix_Build_Script.sh* in `/livecd-creator/FedoraRemix`. Use `./Build_Remix_Physical.sh -h` for options (`-v`, `-k`, `-l`).
+. *Recommended:* from the repository root, run *Build_Remix_Physical.sh*. It prompts for the Fedora release (written to *Setup/config.yml* as `fedora_version`; or pre-set Fedora and PXE preferences with *Update_Remix_Config.sh*), offers a kickstart choice, then runs *Prepare_Fedora_Remix_Build.py*, *Prepare_Web_Files.py*, and *Enhanced_Remix_Build_Script.sh* in `/livecd-creator/FedoraRemix`. Use `./Build_Remix_Physical.sh -h` for options (`-v`, `-k`, `-l`).
 +
 [source,bash]
 .Run *Build_Remix_Physical.sh* (native / physical build driver)
@@ -153,7 +171,7 @@ Setup complete!
 ----
 
 
-. Perform system and package customizations by modifying the *FedoraRemix.ks* kickstart file and the *FedoraRemixPackages.ks* file (under */livecd-creator/FedoraRemix* after the prepare step). The default *Setup/config.yml* `fedora_version` is updated for you if you use *Build_Remix_Physical.sh*; otherwise set it before or between prepare steps.
+. Perform system and package customizations by modifying the *FedoraRemix.ks* kickstart file and the *FedoraRemixPackages.ks* file (under */livecd-creator/FedoraRemix* after the prepare step). The default *Setup/config.yml* `fedora_version` is updated for you if you use *Build_Remix_Physical.sh*; otherwise use *Update_Remix_Config.sh* or set `fedora_version` (and PXE settings) before or between prepare steps.
 .. The setup scripts create the */livecd-creator/FedoraRemix* directory. That is where you edit kickstarts and where the ISO (e.g. *FedoraRemix.iso*) is written after a successful build.
 +
 [source,bash]

--- a/Setup/Kickstarts/FedoraRemixCosmicPackages.ks
+++ b/Setup/Kickstarts/FedoraRemixCosmicPackages.ks
@@ -1,5 +1,6 @@
 ## Travis's Custom Packages for COSMIC Desktop Remix
-%packages
+## --ignoremissing: util-linux-script exists only on Fedora 42+ (script ships in util-linux on F41)
+%packages --ignoremissing
 
 # Remove GNOME-related groups (the '-' prefix excludes them)
 -@gnome-desktop
@@ -165,7 +166,7 @@ util-linux-script
 
 ## Artur's CLI Utils
 zoxide
-eza ## Needs repo
+eza
 btop
 bat
 yazi  ## Needs repo

--- a/Setup/Kickstarts/FedoraRemixLabPackages.ks
+++ b/Setup/Kickstarts/FedoraRemixLabPackages.ks
@@ -1,5 +1,6 @@
 ## Travis's Custom Packages
-%packages
+## --ignoremissing: util-linux-script exists only on Fedora 42+ (script ships in util-linux on F41)
+%packages --ignoremissing
 ## Fix Branding and Logos
 #-fedora-logos
 #-fedora-release*
@@ -107,7 +108,7 @@ copr-cli
 
 ## Artur's CLI Utils
 zoxide
-eza ## Needs repo
+eza
 btop
 bat
 fzf

--- a/Setup/Kickstarts/FedoraRemixPackages.ks
+++ b/Setup/Kickstarts/FedoraRemixPackages.ks
@@ -1,5 +1,6 @@
 ## Travis's Custom Packages
-%packages
+## --ignoremissing: util-linux-script exists only on Fedora 42+ (script ships in util-linux on F41)
+%packages --ignoremissing
 ## Fix Branding and Logos
 #-fedora-logos
 #-fedora-release*
@@ -157,7 +158,7 @@ copr-cli
 
 ## Artur's CLI Utils
 zoxide
-eza ## Needs repo
+eza
 btop
 bat
 yazi  ## Needs repo

--- a/Setup/Kickstarts/FedoraRemixPackagesKDE.ks
+++ b/Setup/Kickstarts/FedoraRemixPackagesKDE.ks
@@ -1,5 +1,6 @@
 ## Travis's Custom Packages
-%packages
+## --ignoremissing: util-linux-script exists only on Fedora 42+ (script ships in util-linux on F41)
+%packages --ignoremissing
 ## Fix Branding and Logos
 #-fedora-logos
 #-fedora-release*
@@ -161,7 +162,7 @@ copr-cli
 
 ## Artur's CLI Utils
 zoxide
-eza ## Needs repo
+eza
 btop
 bat
 yazi  ## Needs repo

--- a/Setup/Kickstarts/FedoraRemixRepos.ks
+++ b/Setup/Kickstarts/FedoraRemixRepos.ks
@@ -1,11 +1,13 @@
 # Extra Repos
+# RPM Fusion: use official metalink — static download1.rpmfusion.org .../releases/N/Everything/... paths
+# often 404 (mirrors move); metalink resolves current mirror URLs per release/arch.
+repo --name="rpmfusion-free" --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-$releasever&arch=$basearch
+repo --name="rpmfusion-nonfree" --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-$releasever&arch=$basearch
 repo --name="google-chrome" --baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
 repo --name="vscode" --baseurl=https://packages.microsoft.com/yumrepos/vscode
-repo --name="rpmfusion-free" --baseurl=https://download1.rpmfusion.org/free/fedora/releases/$releasever/Everything/$basearch/os/
-repo --name="rpmfusion-nonfree" --baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/$releasever/Everything/$basearch/os/
 repo --name="GithubCLITools" --baseurl=https://cli.github.com/packages/rpm
 repo --name="DUST-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/gourlaysama/dust/fedora-$releasever-$basearch/
 repo --name="YAZI-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/lihaohong/yazi/fedora-$releasever-$basearch/
-repo --name="EZA-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/alternateved/eza/fedora-$releasever-$basearch/
+# eza: ship from Fedora rust-eza (do not use alternateved/eza COPR — no F41 chroot; repodata 404).
 repo --name="FedoraRemix-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/tmichett/FedoraRemix/fedora-$releasever-$basearch/ --install --cost=100
 

--- a/Setup/Prepare_Fedora_Remix_Build.py
+++ b/Setup/Prepare_Fedora_Remix_Build.py
@@ -30,6 +30,19 @@ def ensure_root():
         print("This script must be run as root. Please use sudo.")
         sys.exit(1)
 
+def fedora_major_version():
+    """Return Fedora major version id from /etc/os-release, or None if unknown."""
+    try:
+        with open("/etc/os-release", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("VERSION_ID="):
+                    raw = line.split("=", 1)[1].strip().strip('"')
+                    return int(float(raw))
+    except (OSError, ValueError):
+        pass
+    return None
+
 def install_packages(packages):
     """Install packages using dnf/yum"""
     print(f"Installing packages: {', '.join(packages)}")
@@ -76,8 +89,13 @@ def main():
     # Ensure we're running as root
     ensure_root()
     
-    # Variables
-    remix_packages = ["vim", "livecd-tools", "sshfs", "util-linux-script"]
+    # util-linux-script is a separate RPM from Fedora 42 onwards (script/live tools
+    # moved out of util-linux). On Fedora 41 and older, script(1) is in util-linux,
+    # which base installs typically already satisfy.
+    remix_packages = ["vim", "livecd-tools", "sshfs"]
+    major = fedora_major_version()
+    if major is not None and major >= 42:
+        remix_packages.append("util-linux-script")
     remix_directories = [
         "/livecd-creator/FedoraRemix",
         "/livecd-creator/package-cache"

--- a/Setup/Prepare_Web_Files.py
+++ b/Setup/Prepare_Web_Files.py
@@ -7,6 +7,57 @@ import urllib.request
 import sys
 import yaml
 
+def parse_bool(value):
+    """Parse common boolean string values into True/False/None."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    value_str = str(value).strip().lower()
+    if value_str in {"y", "yes", "true", "1", "on"}:
+        return True
+    if value_str in {"n", "no", "false", "0", "off"}:
+        return False
+    return None
+
+def prompt_yes_no(prompt, default=True):
+    """Prompt for yes/no and return bool."""
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        response = input(f"{prompt} {suffix}: ").strip()
+        if not response:
+            return default
+        parsed = parse_bool(response)
+        if parsed is not None:
+            return parsed
+        print("Please answer yes or no.")
+
+def resolve_include_pxeboot_files(config):
+    """
+    Determine whether PXEBoot files should be downloaded.
+    Priority:
+    1) REMIX_INCLUDE_PXEBOOT environment variable
+    2) include_pxeboot_files in config.yml
+    3) interactive prompt (if terminal available)
+    4) default True in non-interactive mode (backward compatible)
+    """
+    env_value = parse_bool(os.environ.get("REMIX_INCLUDE_PXEBOOT"))
+    if env_value is not None:
+        return env_value
+
+    config_value = parse_bool(config.get("include_pxeboot_files"))
+    if config_value is not None:
+        return config_value
+
+    if sys.stdin.isatty():
+        return prompt_yes_no("Include PXEBoot files in web assets?", default=True)
+
+    print("include_pxeboot_files is not defined; defaulting to enabled.")
+    return True
+
 def run_command(command, shell=False):
     """Run a shell command and return the output"""
     cmd_str = ' '.join(command) if isinstance(command, list) else command
@@ -130,6 +181,9 @@ def main():
     fedora_boot_files = config['fedora_boot_files']
     fedora_version = config['fedora_version']
     web_root = config['web_root']
+    include_pxeboot_files = resolve_include_pxeboot_files(config)
+
+    print(f"PXEBoot files enabled: {include_pxeboot_files}")
     
     # Install required packages
     install_packages("httpd")
@@ -164,14 +218,17 @@ def main():
     clone_git_repo("https://github.com/tmichett/FedoraRemixCustomize.git", f"{web_root}/FedoraRemixCustomize")
     clone_git_repo("https://github.com/tmichett/PXEServer.git", f"{web_root}/PXEServer")
     
-    # Create PXE Boot Files directory
-    create_directory(f"{web_root}/FedoraRemixPXE")
-    
-    # Download Boot Images for PXEBoot
-    for file in fedora_boot_files:
-        url = f"https://download.fedoraproject.org/pub/fedora/linux/releases/{fedora_version}/Server/x86_64/os/images/pxeboot/{file}"
-        dest = f"{web_root}/FedoraRemixPXE/{file}"
-        download_file(url, dest)
+    if include_pxeboot_files:
+        # Create PXE Boot Files directory
+        create_directory(f"{web_root}/FedoraRemixPXE")
+
+        # Download Boot Images for PXEBoot
+        for file in fedora_boot_files:
+            url = f"https://download.fedoraproject.org/pub/fedora/linux/releases/{fedora_version}/Server/x86_64/os/images/pxeboot/{file}"
+            dest = f"{web_root}/FedoraRemixPXE/{file}"
+            download_file(url, dest)
+    else:
+        print("Skipping PXEBoot files download (disabled by configuration).")
     
     # Create and Synchronize Scripts Directory
     scripts_dir = "../YAD/scripts"

--- a/Setup/config.yml
+++ b/Setup/config.yml
@@ -10,3 +10,5 @@ fedora_version: 43
 
 # Web root directory where files will be served
 web_root: "/var/www/html"
+
+include_pxeboot_files: false

--- a/Setup/config.yml
+++ b/Setup/config.yml
@@ -6,9 +6,9 @@ fedora_boot_files:
   - "initrd.img"
 
 # Fedora version to use for downloading boot files
-fedora_version: 44
+fedora_version: 43
 
 # Web root directory where files will be served
 web_root: "/var/www/html"
 
-include_pxeboot_files: false
+include_pxeboot_files: true

--- a/Setup/config.yml
+++ b/Setup/config.yml
@@ -6,7 +6,7 @@ fedora_boot_files:
   - "initrd.img"
 
 # Fedora version to use for downloading boot files
-fedora_version: 43
+fedora_version: 44
 
 # Web root directory where files will be served
 web_root: "/var/www/html"

--- a/Update_Remix_Config.sh
+++ b/Update_Remix_Config.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Update_Remix_Config.sh — Interactive update of Fedora version and PXE boot options
+# in config.yml (container) and Setup/config.yml (remix / web prepare).
+#
+
+set -e
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CONTAINER_CONFIG="$SCRIPT_DIR/config.yml"
+readonly SETUP_CONFIG="$SCRIPT_DIR/Setup/config.yml"
+
+show_usage() {
+    echo "Usage: $0 [-h|--help]"
+    echo ""
+    echo "Prompts for Fedora release number and whether to include PXE boot files,"
+    echo "then updates:"
+    echo "  - config.yml              → Container_Properties.Fedora_Version"
+    echo "  - Setup/config.yml        → fedora_version, include_pxeboot_files"
+}
+
+get_container_fedora_version() {
+    if [ ! -f "$CONTAINER_CONFIG" ]; then
+        return 1
+    fi
+    grep -A 20 "Container_Properties:" "$CONTAINER_CONFIG" | grep "Fedora_Version:" | awk '{print $2}' | tr -d '"'
+}
+
+get_setup_fedora_version() {
+    if [ ! -f "$SETUP_CONFIG" ]; then
+        return 1
+    fi
+    grep "^fedora_version:" "$SETUP_CONFIG" | awk '{print $2}' | tr -d '"'
+}
+
+get_include_pxeboot_setting() {
+    local raw
+    raw=$(grep '^include_pxeboot_files:' "$SETUP_CONFIG" 2>/dev/null | awk '{print $2}' | tr -d '"' || true)
+    if [ -z "$raw" ]; then
+        echo ""
+        return 1
+    fi
+    case "$(echo "$raw" | tr '[:upper:]' '[:lower:]')" in
+        true|yes) echo "true" ;;
+        false|no) echo "false" ;;
+        *) echo "" ; return 1 ;;
+    esac
+}
+
+normalize_yes_no_input() {
+    local value
+    value=$(echo "$1" | tr '[:upper:]' '[:lower:]' | xargs)
+    case "$value" in
+        y|yes|true|1|on) echo "true" ;;
+        n|no|false|0|off) echo "false" ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_fedora_version() {
+    local v="$1"
+    if [[ ! "$v" =~ ^[0-9]+$ ]]; then
+        echo "Error: Fedora version must be a positive integer (got: '$v')" >&2
+        return 1
+    fi
+    if [ "$v" -lt 30 ] || [ "$v" -gt 99 ]; then
+        echo "Error: Fedora version must be between 30 and 99 (got: $v)" >&2
+        return 1
+    fi
+    return 0
+}
+
+write_container_fedora_version() {
+    local v="$1"
+    if ! grep -q '^[[:space:]]*Fedora_Version:' "$CONTAINER_CONFIG"; then
+        echo "Error: No Fedora_Version: line found in $CONTAINER_CONFIG" >&2
+        return 1
+    fi
+    sed -i "s/^\([[:space:]]*Fedora_Version:[[:space:]]*\).*/\1\"${v}\"/" "$CONTAINER_CONFIG"
+}
+
+write_setup_fedora_version() {
+    local v="$1"
+    if ! grep -q '^fedora_version:' "$SETUP_CONFIG"; then
+        echo "Error: No fedora_version: line found in $SETUP_CONFIG" >&2
+        return 1
+    fi
+    sed -i "s/^fedora_version:.*/fedora_version: ${v}/" "$SETUP_CONFIG"
+}
+
+write_setup_include_pxeboot() {
+    local value="$1"
+    if grep -q '^include_pxeboot_files:' "$SETUP_CONFIG"; then
+        sed -i "s/^include_pxeboot_files:.*/include_pxeboot_files: ${value}/" "$SETUP_CONFIG"
+    else
+        printf '\ninclude_pxeboot_files: %s\n' "$value" >> "$SETUP_CONFIG"
+    fi
+}
+
+prompt_fedora_version() {
+    local default="$1"
+    local input=""
+    while true; do
+        read -r -p "Fedora version [${default}]: " input
+        if [ -z "$input" ]; then
+            echo "$default"
+            return
+        fi
+        if validate_fedora_version "$input"; then
+            echo "$input"
+            return
+        fi
+    done
+}
+
+prompt_pxe_boot() {
+    local default_bool="$1"
+    local prompt_suffix="[y/N]"
+    [ "$default_bool" = "true" ] && prompt_suffix="[Y/n]"
+
+    local input normalized
+    while true; do
+        read -r -p "Include PXE boot files in web assets? ${prompt_suffix} " input
+        if [ -z "$input" ]; then
+            echo "$default_bool"
+            return
+        fi
+        normalized=$(normalize_yes_no_input "$input") || true
+        if [ -n "$normalized" ]; then
+            echo "$normalized"
+            return
+        fi
+        echo "Please answer yes or no."
+    done
+}
+
+main() {
+    case "${1:-}" in
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+    esac
+
+    if [ ! -f "$CONTAINER_CONFIG" ]; then
+        echo "Error: $CONTAINER_CONFIG not found." >&2
+        exit 1
+    fi
+    if [ ! -f "$SETUP_CONFIG" ]; then
+        echo "Error: $SETUP_CONFIG not found." >&2
+        exit 1
+    fi
+
+    local cv sv default_ver pxe_default
+    cv=$(get_container_fedora_version || true)
+    sv=$(get_setup_fedora_version || true)
+
+    if [ -n "$sv" ]; then
+        default_ver="$sv"
+    elif [ -n "$cv" ]; then
+        default_ver="$cv"
+    else
+        echo "Error: Could not read fedora_version from configs." >&2
+        exit 1
+    fi
+
+    if [ -n "$cv" ] && [ -n "$sv" ] && [ "$cv" != "$sv" ]; then
+        echo "Note: config.yml has Fedora_Version ${cv}, Setup/config.yml has fedora_version ${sv}."
+        echo "      This update will set both to the same value."
+        echo ""
+    fi
+
+    pxe_default="false"
+    if pxe_raw=$(get_include_pxeboot_setting); then
+        if [ "$pxe_raw" = "true" ]; then
+            pxe_default="true"
+        fi
+    fi
+
+    echo "Update remix configuration (container + Setup)."
+    echo ""
+
+    local target_ver pxe_bool
+    target_ver=$(prompt_fedora_version "$default_ver")
+    pxe_bool=$(prompt_pxe_boot "$pxe_default")
+
+    write_container_fedora_version "$target_ver"
+    write_setup_fedora_version "$target_ver"
+    write_setup_include_pxeboot "$pxe_bool"
+
+    echo ""
+    echo "Updated:"
+    echo "  $CONTAINER_CONFIG  → Fedora_Version \"${target_ver}\""
+    echo "  $SETUP_CONFIG      → fedora_version: ${target_ver}, include_pxeboot_files: ${pxe_bool}"
+}
+
+main "$@"

--- a/Verify_Build_Remix.sh
+++ b/Verify_Build_Remix.sh
@@ -27,6 +27,7 @@ readonly ROCKET="🚀"
 
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_CONFIG="$SCRIPT_DIR/Setup/config.yml"
 
 # Function to print colored messages
 print_message() {
@@ -84,6 +85,67 @@ get_remix_fedora_version() {
         return 1
     fi
     echo "$version"
+}
+
+normalize_yes_no() {
+    local value
+    value=$(echo "$1" | tr '[:upper:]' '[:lower:]' | xargs)
+    case "$value" in
+        y|yes|true|1|on)
+            echo "true"
+            return 0
+            ;;
+        n|no|false|0|off)
+            echo "false"
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+get_include_pxeboot_setting() {
+    if [ ! -f "$SETUP_CONFIG" ]; then
+        return 1
+    fi
+
+    local raw
+    raw=$(grep '^include_pxeboot_files:' "$SETUP_CONFIG" | awk '{print $2}' | tr -d '"' || true)
+    if [ -z "$raw" ]; then
+        return 1
+    fi
+
+    normalize_yes_no "$raw"
+}
+
+write_setup_include_pxeboot() {
+    local value="$1"
+    if grep -q '^include_pxeboot_files:' "$SETUP_CONFIG"; then
+        sed -i "s/^include_pxeboot_files:.*/include_pxeboot_files: ${value}/" "$SETUP_CONFIG"
+    else
+        printf '\ninclude_pxeboot_files: %s\n' "$value" >> "$SETUP_CONFIG"
+    fi
+}
+
+prompt_include_pxeboot() {
+    local default="${1:-true}"
+    local prompt_suffix="[Y/n]"
+    [ "$default" = "false" ] && prompt_suffix="[y/N]"
+    local input=""
+    local normalized=""
+
+    while true; do
+        read -r -p "$(echo -e "${BOLD}${WHITE}Include PXEBoot files in web assets? ${prompt_suffix}: ${NC}")" input
+        if [ -z "$input" ]; then
+            echo "$default"
+            return
+        fi
+        normalized=$(normalize_yes_no "$input" || true)
+        if [ -n "$normalized" ]; then
+            echo "$normalized"
+            return
+        fi
+        print_message "WARNING" "Please answer yes or no."
+    done
 }
 
 # Function to get GitHub registry owner
@@ -152,6 +214,23 @@ main() {
         print_message "ERROR" "Failed to read GitHub registry owner from config.yml"
         exit 1
     fi
+
+    local include_pxeboot
+    if [ -n "${REMIX_INCLUDE_PXEBOOT:-}" ]; then
+        include_pxeboot=$(normalize_yes_no "${REMIX_INCLUDE_PXEBOOT}" || true)
+        if [ -z "$include_pxeboot" ]; then
+            print_message "ERROR" "Invalid REMIX_INCLUDE_PXEBOOT value: ${REMIX_INCLUDE_PXEBOOT} (use true/false)"
+            exit 1
+        fi
+    else
+        include_pxeboot=$(get_include_pxeboot_setting || true)
+        if [ -z "$include_pxeboot" ]; then
+            print_message "INFO" "Setup/config.yml has no include_pxeboot_files setting."
+            include_pxeboot=$(prompt_include_pxeboot "true")
+            write_setup_include_pxeboot "$include_pxeboot"
+            print_message "SUCCESS" "Saved include_pxeboot_files: ${include_pxeboot} in Setup/config.yml"
+        fi
+    fi
     
     # Construct image name
     IMAGE_NAME="ghcr.io/${GITHUB_OWNER}/fedora-remix-builder:${CONTAINER_VERSION}"
@@ -168,6 +247,7 @@ main() {
     echo -e "${BOLD}${CYAN}║${NC}                                                                      ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}  ${GREEN}Remix Configuration${NC} (Setup/config.yml)                            ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}    Fedora Version: ${WHITE}${REMIX_VERSION}${NC}                                            ${BOLD}${CYAN}║${NC}"
+    echo -e "${BOLD}${CYAN}║${NC}    Include PXEBoot: ${WHITE}${include_pxeboot}${NC}                                       ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}    ISO Output: ${WHITE}FedoraRemix-${REMIX_VERSION}.iso${NC}                                ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}║${NC}                                                                      ${BOLD}${CYAN}║${NC}"
     echo -e "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════════════╝${NC}"
@@ -237,13 +317,13 @@ main() {
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         print_message "SUCCESS" "Starting build process..."
         echo ""
-        print_message "INFO" "Executing: ./Build_Remix.sh"
+        print_message "INFO" "Executing: ./Build_Remix.sh (REMIX_INCLUDE_PXEBOOT=${include_pxeboot})"
         echo ""
         echo -e "${CYAN}════════════════════════════════════════════════════════════════════════${NC}"
         echo ""
         
         # Execute the build script
-        exec "$SCRIPT_DIR/Build_Remix.sh"
+        exec env REMIX_INCLUDE_PXEBOOT="$include_pxeboot" "$SCRIPT_DIR/Build_Remix.sh"
     else
         print_message "INFO" "Build cancelled by user"
         echo ""

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 Container_Properties:
-  Fedora_Version: "44"
+  Fedora_Version: "43"
   SSH_Key_Location: "~/.ssh/github_id"
   Fedora_Remix_Location: "/home/travis/Remix_Builder"
   GitHub_Registry_Owner: "tmichett"

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 Container_Properties:
-  Fedora_Version: "43"
+  Fedora_Version: "44"
   SSH_Key_Location: "~/.ssh/github_id"
   Fedora_Remix_Location: "/home/travis/Remix_Builder"
   GitHub_Registry_Owner: "tmichett"


### PR DESCRIPTION
## Summary
Prepares the repo for **Fedora 44**, improves **PXE / web-boot** ergonomics (**optional `include_pxeboot_files`**), fixes several **Fedora 41+ build/prep pitfalls**, refreshes docs, and adds **`Update_Remix_Config.sh`** so users rarely hand-edit **`config.yml`** / **`Setup/config.yml`**.

## Highlights
### Config UX
- **`Update_Remix_Config.sh`**: Interactive **Fedora version** plus **PXE Linux** (`vmlinuz`/`initrd`) toggle; writes **`Container_Properties.Fedora_Version`** and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`**.
- **`Quickstart_Container` / `Quickstart_Physical` / `README_Physical.adoc`**: Document the script, PXE caveats (EOL / very new releases), and when to answer **no** to PXE.

### Builds & tooling
- **`Build_Remix.sh`**, **`Build_Remix_Physical.sh`**, **`Verify_Build_Remix.sh`**: Respect **`REMIX_INCLUDE_PXEBOOT`**, propagate to **`Prepare_Web_Files.py`** / env, summarize in menus.
- **`Prepare_Web_Files.py`**: Conditional PXE downloads (`include_pxeboot_files` / env / prompt).
- **`Prepare_Fedora_Remix_Build.py`**: Install **`util-linux-script`** only on **Fedora ≥ 42** (avoids missing package on **F41**).

### Repo / mirrors
- **`FedoraRemixRepos.ks`**: RPM Fusion via **metalinks** (fixes **404** on static `download1` paths).
- **EZA COPR**: Dropped (**`eza`** from Fedora **`rust-eza`**); **`%packages --ignoremissing`** where **`util-linux-script`** varies by release.

## Companion PR
- **RemixBuilder** [#6](https://github.com/tmichett/RemixBuilder/pull/6) — **`console-getty`** masking to stop host flicker during privileged builds.

## Checklist
- [ ] `Verify_Build_Remix.sh` ↔ **`config.yml`** / **`Setup/config.yml`** versions match
- [ ] **No PXE**: `include_pxeboot_files: false` if not serving network boot
- [ ] Builder image **`ghcr.io/tmichett/fedora-remix-builder:{44}`** available before relying on `:44`

---
**Commits**: Preparation for Fedora 44/PXE, Fedora 44 config, build-script + documentation updates.