### PR TITLE
feat: Extend Update_Remix_Config for SSH path, remix dir, registry owner; sync docs

### DIFF
--- a/Notes/Fedora_Remix_Quickstart.md
+++ b/Notes/Fedora_Remix_Quickstart.md
@@ -117,8 +117,10 @@ sudo dnf install -y \
     python3 \
     vim \
     git \
-    rsync \
-    util-linux-script
+    rsync
+
+# Fedora 42+: install util-linux-script if you need standalone script(1) split from util-linux
+# (Prepare_Fedora_Remix_Build.py adds this automatically on F42+.)
 
 # HTTP server for hosting files during build
 sudo dnf install -y httpd
@@ -142,24 +144,24 @@ sudo dnf install -y curl wget
 | `vim` | Text editor for configuration |
 | `git` | Version control and repository cloning |
 | `rsync` | File synchronization |
-| `util-linux-script` | Script command for build logging |
+| `util-linux-script` | (Fedora 42+) Optional; `script` for livecd logging — on older Fedora it is in **`util-linux`** |
 
 ### Manual Build Steps (Without Container)
 
+Prefer **`./Build_Remix_Physical.sh`** from the Fedora_Remix repo root (sets version/PXE prompts, runs prepare scripts, then the enhanced livecd build).
+
+Manual equivalent — **prepare build tree first**, then web files ([README_Scripts_Usage.md](../README_Scripts_Usage.md)):
+
 ```bash
-# 1. Navigate to the Setup directory
 cd Fedora_Remix/Setup
 
-# 2. Run the web files preparation script
-sudo python3 Prepare_Web_Files.py
-
-# 3. Run the build preparation script
+# 1. Create /livecd-creator/FedoraRemix and copy kickstarts/scripts
 sudo python3 Prepare_Fedora_Remix_Build.py
 
-# 4. Navigate to the build directory
-cd /livecd-creator/FedoraRemix
+# 2. Configure httpd / web assets (optional: PXE files per Setup/config.yml)
+sudo python3 Prepare_Web_Files.py
 
-# 5. Run the build script
+cd /livecd-creator/FedoraRemix
 sudo ./Enhanced_Remix_Build_Script.sh
 ```
 
@@ -188,23 +190,16 @@ git clone https://github.com/tmichett/Fedora_Remix_Tools.git
 
 ### Step 2: Configure the Build
 
-1. **Edit RemixBuilder `config.yml`**:
+1. **In your `Fedora_Remix` clone**, align versions and PXE options (recommended):
+   ```bash
+   cd Fedora_Remix
+   ./Update_Remix_Config.sh
+   ```
+   Then edit root **`config.yml`** for paths: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** (image name is derived from owner + **`Fedora_Version`**).
 
-```yaml
-Container_Properties:
-  Fedora_Version: "43"                              # Target Fedora version
-  SSH_Key_Location: "~/.ssh/github_id"              # Your GitHub SSH key
-  Fedora_Remix_Location: "/path/to/Fedora_Remix"   # Path to Fedora_Remix project
-  GitHub_Registry_Owner: "your-username"            # GitHub username
-  Image_Name: "ghcr.io/your-username/fedora-remix-builder:43"
-```
+2. **RemixBuilder `config.yml`** (if you build/push the container image from [RemixBuilder](https://github.com/tmichett/RemixBuilder)): set **`Fedora_Version`** to the same numeric release as **`Fedora_Remix/Setup/config.yml`**. Optionally copy this file into the Fedora_Remix repo root for **`Build_Remix.sh`**.
 
-2. **Verify version consistency** in `Fedora_Remix/Setup/config.yml`:
-
-```yaml
-fedora_version: 43  # Must match RemixBuilder config
-web_root: "/var/www/html"
-```
+3. **`Fedora_Remix/Setup/config.yml`** — after **`Update_Remix_Config.sh`**, **`fedora_version`** matches **`Fedora_Version`**; keep **`web_root`** and **`include_pxeboot_files`** as documented in [Quickstart_Container.md](../Quickstart_Container.md).
 
 ### Step 3: Build and Run
 
@@ -216,7 +211,8 @@ cd RemixBuilder
 # Option B: Use pre-built container from registry
 # (Skip build.sh if image already exists)
 
-# Run the build
+# Run the build from the Fedora_Remix repo root (where Build_Remix.sh lives)
+cd /path/to/Fedora_Remix
 ./Build_Remix.sh
 ```
 
@@ -233,33 +229,20 @@ After successful build, the ISO is located at:
 
 ### Where to Change the Fedora Version
 
-When building for a new Fedora version (e.g., upgrading from 43 to 44), you must update the version in **multiple locations**:
+When building for a new Fedora version (e.g., upgrading from 43 to 44), keep settings aligned.
 
-#### 1. RemixBuilder Configuration
+**Fastest:** from **`Fedora_Remix`**, run **`./Update_Remix_Config.sh`** — it updates **`Fedora_Version`** (root `config.yml`) and **`fedora_version`** (`Setup/config.yml`) together.
 
-**File:** `RemixBuilder/config.yml`
+#### 1. RemixBuilder Configuration (container image)
 
-```yaml
-Container_Properties:
-  Fedora_Version: "43"  # ← Change this to your target version
-  # ...
-  Image_Name: "ghcr.io/your-username/fedora-remix-builder:43"  # ← Update tag to match
-```
-
-This controls:
-- The base Fedora image used for the container
-- The container image tag
+**File:** `RemixBuilder/config.yml` — set **`Fedora_Version`** to your target (e.g. `"44"`). Image tag is **`ghcr.io/{GitHub_Registry_Owner}/fedora-remix-builder:{Fedora_Version}`** (no separate `Image_Name` field in current trees).
 
 #### 2. Setup Configuration
 
-**File:** `Fedora_Remix/Setup/config.yml`
-
-```yaml
-fedora_version: 43  # ← Change this to your target version
-```
+**File:** `Fedora_Remix/Setup/config.yml` — **`fedora_version`** must match **`Fedora_Version`**. Use **`Update_Remix_Config.sh`** or edit by hand.
 
 This controls:
-- PXE boot file downloads from the correct Fedora version
+- PXE boot file downloads from the correct Fedora version (when **`include_pxeboot_files`** is true)
 - Version displayed in build messages
 
 #### 3. Build Scripts (Automatic)
@@ -531,6 +514,7 @@ fedora_boot_files:
   - "initrd.img"
 fedora_version: 43
 web_root: "/var/www/html"
+include_pxeboot_files: false
 ```
 
 ### `Prepare_Fedora_Remix_Build.py`
@@ -541,7 +525,8 @@ This script prepares the livecd-creator build environment.
 
 1. **Installs Required Packages**
    ```python
-   remix_packages = ["vim", "livecd-tools", "sshfs", "util-linux-script"]
+   remix_packages = ["vim", "livecd-tools", "sshfs"]
+   # util-linux-script appended on Fedora 42+ (see Prepare_Fedora_Remix_Build.py)
    install_packages(remix_packages)
    ```
 
@@ -722,15 +707,14 @@ fzf
 ### FedoraRemixRepos.ks - Third-Party Repositories
 
 ```kickstart
-# Extra Repos
+# Extra Repos (RPM Fusion uses metalinks; eza ships from Fedora rust-eza — see FedoraRemixRepos.ks)
+repo --name="rpmfusion-free" --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-$releasever&arch=$basearch
+repo --name="rpmfusion-nonfree" --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-$releasever&arch=$basearch
 repo --name="google-chrome" --baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
 repo --name="vscode" --baseurl=https://packages.microsoft.com/yumrepos/vscode
-repo --name="rpmfusion-free" --baseurl=https://download1.rpmfusion.org/free/fedora/releases/$releasever/Everything/$basearch/os/
-repo --name="rpmfusion-nonfree" --baseurl=https://download1.rpmfusion.org/nonfree/fedora/releases/$releasever/Everything/$basearch/os/
 repo --name="GithubCLITools" --baseurl=https://cli.github.com/packages/rpm
 repo --name="DUST-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/gourlaysama/dust/fedora-$releasever-$basearch/
 repo --name="YAZI-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/lihaohong/yazi/fedora-$releasever-$basearch/
-repo --name="EZA-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/alternateved/eza/fedora-$releasever-$basearch/
 repo --name="FedoraRemix-COPR" --baseurl=https://download.copr.fedorainfracloud.org/results/tmichett/FedoraRemix/fedora-$releasever-$basearch/
 ```
 

--- a/Notes/Fedora_Remix_Quickstart.md
+++ b/Notes/Fedora_Remix_Quickstart.md
@@ -190,12 +190,12 @@ git clone https://github.com/tmichett/Fedora_Remix_Tools.git
 
 ### Step 2: Configure the Build
 
-1. **In your `Fedora_Remix` clone**, align versions and PXE options (recommended):
+1. **In your `Fedora_Remix` clone**, align paths, registry owner, versions, and PXE (recommended):
    ```bash
    cd Fedora_Remix
    ./Update_Remix_Config.sh
    ```
-   Then edit root **`config.yml`** for paths: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** (image name is derived from owner + **`Fedora_Version`**).
+   The script prompts for **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**, and PXE (**`include_pxeboot_files`**). Optionally pre-edit root **`config.yml`** so **[bracket]** defaults match your host. If you use **`ghcr.io/tmichett/fedora-remix-builder`**, keep **`GitHub_Registry_Owner`** **`tmichett`** (image name is `ghcr.io/{owner}/fedora-remix-builder:{Fedora_Version}`).
 
 2. **RemixBuilder `config.yml`** (if you build/push the container image from [RemixBuilder](https://github.com/tmichett/RemixBuilder)): set **`Fedora_Version`** to the same numeric release as **`Fedora_Remix/Setup/config.yml`**. Optionally copy this file into the Fedora_Remix repo root for **`Build_Remix.sh`**.
 
@@ -231,7 +231,7 @@ After successful build, the ISO is located at:
 
 When building for a new Fedora version (e.g., upgrading from 43 to 44), keep settings aligned.
 
-**Fastest:** from **`Fedora_Remix`**, run **`./Update_Remix_Config.sh`** — it updates **`Fedora_Version`** (root `config.yml`) and **`fedora_version`** (`Setup/config.yml`) together.
+**Fastest:** from **`Fedora_Remix`**, run **`./Update_Remix_Config.sh`** — it updates **`Container_Properties`** on the remix side (`SSH_Key_Location`, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**) and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`** together.
 
 #### 1. RemixBuilder Configuration (container image)
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,5 +1,12 @@
 # Fedora Remix Builder - Quick Reference Card
 
+## Configuration snapshot
+
+```bash
+cd /home/travis/Github/Fedora_Remix
+./Update_Remix_Config.sh    # Fedora version + PXE toggle; syncs root config.yml + Setup/config.yml
+```
+
 ## Building an ISO
 
 ```bash
@@ -83,14 +90,13 @@ cd /home/travis/Github/Fedora_Remix
 **Solution**: Update to latest scripts (includes Python version detection)  
 **Details**: See [LINUX_BUILD_FIX.md](LINUX_BUILD_FIX.md)
 
-### ❌ "Could not extract Image_Name from config.yml"
-```bash
-# Check config.yml format
-cat config.yml
+### ❌ "Could not extract … from config.yml"
 
-# Should have:
-Container_Properties:
-  Image_Name: "ghcr.io/tmichett/fedora-remix-builder:43"
+```bash
+cat config.yml
+# Contemporary trees use Container_Properties.Fedora_Version + GitHub_Registry_Owner
+# Image name defaults to: ghcr.io/{GitHub_Registry_Owner}/fedora-remix-builder:{Fedora_Version}
+./Update_Remix_Config.sh   # if versions are out of sync
 ```
 
 ### ❌ Container stuck in "Stopping" state

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -4,7 +4,7 @@
 
 ```bash
 cd /home/travis/Github/Fedora_Remix
-./Update_Remix_Config.sh    # Fedora version + PXE toggle; syncs root config.yml + Setup/config.yml
+./Update_Remix_Config.sh    # SSH path, remix dir, registry owner, Fedora + PXE; syncs root config.yml + Setup/config.yml (keep owner tmichett for ghcr.io/tmichett/…)
 ```
 
 ## Building an ISO

--- a/Quickstart_Container.adoc
+++ b/Quickstart_Container.adoc
@@ -16,9 +16,13 @@ This guide walks you through a **Podman-based** remix build: the workload runs i
 .Standard configuration order (recommended)
 [start=1]
 . *Clone:* `git clone https://github.com/tmichett/Fedora_Remix.git` and `cd Fedora_Remix`.
-. *Root `config.yml` (paths and registry):* set `SSH_Key_Location`, `Fedora_Remix_Location`, and `GitHub_Registry_Owner`. (`Fedora_Version` can be adjusted in the next step.)
-. *Version + PXE:* run `./Update_Remix_Config.sh` — updates `Fedora_Version` in `config.yml` and `fedora_version` plus `include_pxeboot_files` in `Setup/config.yml` together (preferred to editing both files by hand).
+. *Configure:* run `./Update_Remix_Config.sh` — prompts for `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version`, and PXE (`include_pxeboot_files`). Press *Enter* at any prompt to keep the value shown in brackets (defaults come from `config.yml`). Optionally pre-seed `config.yml` so those defaults match your host (see *Step 2*).
 . *Verify / build:* `./Verify_Build_Remix.sh` (recommended) or `./Build_Remix.sh`.
+
+[NOTE]
+====
+If you use the *published* builder image at `ghcr.io/tmichett/fedora-remix-builder`, keep `GitHub_Registry_Owner` set to `tmichett` so pulls and verification resolve the same image (the script reminds you before that prompt).
+====
 
 PXE/web assets (`Prepare_Web_Files.py` inside the build): enable `include_pxeboot_files` only when you intentionally stage **`vmlinuz`** / **`initrd`** for network boot tooling. Use *false* (answer *no*) for a normal ISO-only build—see IMPORTANT under *Step 3* below; fragile mirrors on older or unreleased Fedora can fail the prepare step if PXE downloads are forced on.
 
@@ -109,13 +113,11 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ----
 
-=== Step 2: Container-specific settings in `config.yml`
+=== Step 2: Container-specific settings in `config.yml` — optional
 
-Edit the repository root **`config.yml`** for everything the Podman workflows need *besides* the numeric Fedora coupling (handled in **Step 3**):
+The repository root **`config.yml`** holds `Container_Properties` used by *Build_Remix.sh* / *Verify_Build_Remix.sh*. You do *not* have to edit this file by hand: **`./Update_Remix_Config.sh`** (Step 3) prompts for `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version`, and `include_pxeboot_files` (PXE), writing values back to YAML safely.
 
-- `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner` are *only* adjusted here.
-
-You *may* set `Fedora_Version` here temporarily, but **`./Update_Remix_Config.sh`** (Step 3) overwrites **`Fedora_Version`** and **`Setup/config.yml`** so both stay identical—prefer running Step 3 every time you change distro release.
+*When to edit here first:* copy in a `config.yml` from another machine, or set paths/registry before running the script — those values become the *[bracket]* defaults at each prompt. You *may* still set `Fedora_Version` temporarily; Step 3 aligns `Fedora_Version`, `fedora_version` (*Setup/config.yml*), and PXE whenever you run it.
 
 [source,bash]
 ----
@@ -148,7 +150,7 @@ Container_Properties:
 |Where the ISO and build artifacts will be saved
 
 |`GitHub_Registry_Owner`
-|GitHub username/org that hosts the container image
+|Used in `ghcr.io/{owner}/fedora-remix-builder:{tag}`. If you pull the *published* `ghcr.io/tmichett/...` image, keep this `tmichett` (the script reminds you before this prompt).
 |===
 
 .Example Configuration
@@ -161,9 +163,9 @@ Container_Properties:
   GitHub_Registry_Owner: "tmichett"
 ----
 
-=== Step 3: Fedora release and PXE (*Update_Remix_Config.sh* — recommended)
+=== Step 3: Paths, registry, Fedora release, and PXE (*Update_Remix_Config.sh* — recommended)
 
-Instead of manually editing `Fedora_Version` in `config.yml` and `fedora_version` / `include_pxeboot_files` in *Setup/config.yml*, run from the repository root:
+Instead of manually editing *Container_Properties* in `config.yml` and `fedora_version` / `include_pxeboot_files` in *Setup/config.yml*, run from the repository root:
 
 [source,bash]
 ----
@@ -171,7 +173,13 @@ chmod +x Update_Remix_Config.sh
 ./Update_Remix_Config.sh
 ----
 
-The script prompts for the Fedora release and whether to download **PXE Linux** boot artifacts into the web prepare step (*include_pxeboot_files*). When *true*, container prepare stages `vmlinuz` and `initrd.img` for optional **network (PXE/HTTP) boot** tooling on the Remix. If you answer *no*, PXE assets are skipped.
+*Prompts (in order)* — *Enter* keeps the *[bracket]* default (from `config.yml` if present):
+
+. `SSH_Key_Location` — SSH key path for git operations in the container workflow
+. `Fedora_Remix_Location` — host directory for ISO output and build artifacts
+. `GitHub_Registry_Owner` — used to build `ghcr.io/{owner}/fedora-remix-builder:{tag}`; the script prints a reminder that if you use the *published* image under `ghcr.io/tmichett/...`, this value should stay `tmichett`
+. **Fedora release** — sets `Fedora_Version` and `fedora_version` together
+. **PXE/Linux boot images** — whether to download **PXE Linux** artifacts into the web prepare step (*include_pxeboot_files*). When *true*, container prepare stages `vmlinuz` and `initrd.img` for optional **network (PXE/HTTP) boot** tooling on the Remix. If you answer *no*, PXE assets are skipped.
 
 [IMPORTANT]
 ====
@@ -739,7 +747,7 @@ done
 
 * *AsciiDoctor index:* link:docs/README.adoc[docs/README.adoc]
 * *Physical/quickstart (ADOC/PDF):* link:README_Physical.adoc[README_Physical.adoc]
-* *Config helper:* link:Update_Remix_Config.sh[Update_Remix_Config.sh] — align `Fedora_Version`, `fedora_version`, PXE (`include_pxeboot_files`)
+* *Config helper:* link:Update_Remix_Config.sh[Update_Remix_Config.sh] — align `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version`, `fedora_version`, PXE (`include_pxeboot_files`)
 * *Main README:* link:README.md[README.md] - Project overview
 * *Build Fixes:* link:LINUX_BUILD_FIX.md[LINUX_BUILD_FIX.md] - Known issues and solutions
 * *SELinux Fix:* link:SELINUX_RELABEL_FIX.md[SELINUX_RELABEL_FIX.md] - SELinux relabeling fix details
@@ -764,8 +772,7 @@ done
 .Minimum steps to build
 
 . `git clone …/Fedora_Remix.git && cd Fedora_Remix`
-. Edit **`config.yml`**: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
-. `./Update_Remix_Config.sh` — Fedora release + PXE/Linux payload (**no** unless serving PXE)
+. `./Update_Remix_Config.sh` — **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** (keep **`tmichett`** if using **`ghcr.io/tmichett/fedora-remix-builder`**), **`Fedora_Version`**, PXE (**no** unless serving PXE); optional pre-edit **`config.yml`** for defaults
 . `./Verify_Build_Remix.sh` (or `./Build_Remix.sh`)
 . `podman stop remix-builder` when finished inspecting logs
 . ISO beside `${Fedora_Remix_Location}/FedoraRemix/` (`/home/travis/Remix_Builder/...` in examples)
@@ -780,4 +787,4 @@ done
 *That's it!* You now have a custom Fedora Remix ISO ready to use.
 
 [.text-center]
-_Last Updated: April 28, 2026 | Version: 1.3_
+_Last Updated: April 28, 2026 | Version: 1.4_

--- a/Quickstart_Container.adoc
+++ b/Quickstart_Container.adoc
@@ -7,11 +7,20 @@
 :docdate: April 28, 2026
 
 [.lead]
-Quick guide to building a custom Fedora Remix ISO using the containerized build system.
+Quick guide to building a custom Fedora Remix ISO using the Fedora Remix Builder container (`Build_Remix.sh` / `Verify_Build_Remix.sh`).
 
 == Overview
 
-This guide will walk you through building a custom Fedora Remix ISO image using the Fedora Remix Builder container. The entire build process runs in a container, making it consistent across different systems.
+This guide walks you through a **Podman-based** remix build: the workload runs inside the **fedora-remix-builder** image; your host stays outside the compose except for bind-mounted workspace and ISO output paths.
+
+.Standard configuration order (recommended)
+[start=1]
+. *Clone:* `git clone https://github.com/tmichett/Fedora_Remix.git` and `cd Fedora_Remix`.
+. *Root `config.yml` (paths and registry):* set `SSH_Key_Location`, `Fedora_Remix_Location`, and `GitHub_Registry_Owner`. (`Fedora_Version` can be adjusted in the next step.)
+. *Version + PXE:* run `./Update_Remix_Config.sh` — updates `Fedora_Version` in `config.yml` and `fedora_version` plus `include_pxeboot_files` in `Setup/config.yml` together (preferred to editing both files by hand).
+. *Verify / build:* `./Verify_Build_Remix.sh` (recommended) or `./Build_Remix.sh`.
+
+PXE/web assets (`Prepare_Web_Files.py` inside the build): enable `include_pxeboot_files` only when you intentionally stage **`vmlinuz`** / **`initrd`** for network boot tooling. Use *false* (answer *no*) for a normal ISO-only build—see IMPORTANT under *Step 3* below; fragile mirrors on older or unreleased Fedora can fail the prepare step if PXE downloads are forced on.
 
 [cols="1,3"]
 |===
@@ -57,6 +66,8 @@ sudo dnf install osbuild-selinux
 . *Sudo Access* - Required for loop device creation on Linux
 ** The build script will automatically use `sudo` when needed
 
+. *Editor* - Examples use `vim`; `nano`, VS Code, or any editor works for YAML and kickstarts
+
 === Optional: Enable SSH for Remote Access
 
 If you are connecting to the build system *remotely* (e.g., SSHing in from another machine to run builds), enable the SSH daemon:
@@ -80,7 +91,7 @@ This is not needed if you are working directly on the build machine.
 
 === Supported Operating Systems
 
-* ✅ Fedora Linux (39, 40, 41, 42, 43)
+* ✅ Fedora Linux (39–44; newer releases track current Fedora Remix builder tags)
 * ✅ RHEL/CentOS/Rocky/Alma Linux (8, 9)
 * ✅ Ubuntu/Debian (with Podman installed)
 * ✅ macOS (with Podman Desktop)
@@ -100,7 +111,11 @@ cd Fedora_Remix
 
 === Step 2: Container-specific settings in `config.yml`
 
-Edit the main configuration file for paths and registry that the container build uses (SSH key, ISO output directory, GitHub Container Registry owner). You can set `Fedora_Version` here or rely on *Update_Remix_Config.sh* (next step) to align `Fedora_Version` and *Setup/config.yml* for you.
+Edit the repository root **`config.yml`** for everything the Podman workflows need *besides* the numeric Fedora coupling (handled in **Step 3**):
+
+- `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner` are *only* adjusted here.
+
+You *may* set `Fedora_Version` here temporarily, but **`./Update_Remix_Config.sh`** (Step 3) overwrites **`Fedora_Version`** and **`Setup/config.yml`** so both stay identical—prefer running Step 3 every time you change distro release.
 
 [source,bash]
 ----
@@ -193,10 +208,11 @@ Run the verification script to check your configuration:
 ----
 
 .What it checks
-* ✅ Fedora versions match between both config files
-* ✅ Container image availability
-* ✅ Configuration summary
-* ✅ Confirms before building
+* ✅ `Fedora_Version` (`config.yml`) matches `fedora_version` (`Setup/config.yml`)
+* ✅ Prints **`include_pxeboot_files`** in the remix summary panel (PXE payloads for web prepare)
+* ✅ If **`include_pxeboot_files`** is missing from **`Setup/config.yml`**, prompts once and persists the answer (unless **`REMIX_INCLUDE_PXEBOOT`**=`true`|`false` is set in the environment)
+* ✅ Resolves **`ghcr.io/{owner}/fedora-remix-builder:{tag}`**, confirms or pulls image
+* ✅ Confirms before handing off to `./Build_Remix.sh` — passes **`REMIX_INCLUDE_PXEBOOT`** through so container prepare honors your PXE choice
 
 .Sample Output
 ----
@@ -216,24 +232,51 @@ Do you want to proceed with the build? [y/N]: y
 
 === Step 5: Build the ISO
 
-If you used the verification script and confirmed, the build starts automatically.
+If you confirmed at the end of *Step 4*, the build starts automatically (`Verify_Build_Remix.sh` invokes `./Build_Remix.sh`).
 
-Otherwise, run the build script directly:
+Otherwise:
 
 [source,bash]
 ----
 ./Build_Remix.sh
 ----
 
-.Build Process
-. Container starts with systemd
-. Prepares build environment
-. Downloads and installs packages (~15-20 minutes)
-. Runs post-installation scripts
-. Creates the ISO image (~5-10 minutes)
-. ISO saved to your configured output directory
+==== Default detached mode / log streaming
 
-.Expected Output Location
+Unless you pass `--attach` or set `REMIX_BUILD_ATTACH=1`, `./Build_Remix.sh` keeps the builder container detached and streams output by following `/tmp/entrypoint.log` in your current terminal (no separate `podman logs` pane required).
+
+==== Stop container after ISO work
+
+When the log follow ends:
+
+[source,bash]
+----
+podman stop remix-builder
+----
+
+Match **`sudo`** to how invoked on your machine (`sudo podman stop remix-builder`, etc.).
+
+==== Attach-old-behavior toggle
+
+Pass `--attach` (or **`REMIX_BUILD_ATTACH=1`**) only if you want the shell attached directly to the container PID 1 stream instead of the host-followed `/tmp/entrypoint.log`.
+
+==== `REMIX_INCLUDE_PXEBOOT` (PXE payloads)
+
+`Verify_Build_Remix.sh` exports **`REMIX_INCLUDE_PXEBOOT`** consistently with **`include_pxeboot_files`**. Driving builds directly:
+
+[source,bash]
+----
+REMIX_INCLUDE_PXEBOOT=false ./Build_Remix.sh
+----
+
+==== Typical entrypoint milestones
+. systemd + hydration (patches bind-mounted from repo)
+. `dnf` installs (~15–25 minutes wall clock)
+. Kickstart `%post`, squashfs assemble, xorriso (**~5–15 minutes**)
+
+.ISO path (GNOME spin default kickstart)
+
+[source,text]
 ----
 /home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso
 ----
@@ -694,6 +737,7 @@ done
 
 === Documentation
 
+* *AsciiDoctor index:* link:docs/README.adoc[docs/README.adoc]
 * *Physical/quickstart (ADOC/PDF):* link:README_Physical.adoc[README_Physical.adoc]
 * *Config helper:* link:Update_Remix_Config.sh[Update_Remix_Config.sh] — align `Fedora_Version`, `fedora_version`, PXE (`include_pxeboot_files`)
 * *Main README:* link:README.md[README.md] - Project overview
@@ -717,14 +761,14 @@ done
 
 == Summary
 
-.Minimum Steps to Build
+.Minimum steps to build
 
-. Clone repository: `git clone https://github.com/tmichett/Fedora_Remix.git`
-. Edit root `config.yml` — SSH key, ISO output directory, registry owner
-. Run `./Update_Remix_Config.sh` — Fedora release plus PXE/Linux assets (**no** recommended unless you need PXE)
-. Run `./Verify_Build_Remix.sh` — Verify and build
-. Wait 30-45 minutes
-. Find ISO at `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
+. `git clone …/Fedora_Remix.git && cd Fedora_Remix`
+. Edit **`config.yml`**: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
+. `./Update_Remix_Config.sh` — Fedora release + PXE/Linux payload (**no** unless serving PXE)
+. `./Verify_Build_Remix.sh` (or `./Build_Remix.sh`)
+. `podman stop remix-builder` when finished inspecting logs
+. ISO beside `${Fedora_Remix_Location}/FedoraRemix/` (`/home/travis/Remix_Builder/...` in examples)
 
 .Optional Customization
 
@@ -736,4 +780,4 @@ done
 *That's it!* You now have a custom Fedora Remix ISO ready to use.
 
 [.text-center]
-_Last Updated: April 28, 2026 | Version: 1.1_
+_Last Updated: April 28, 2026 | Version: 1.3_

--- a/Quickstart_Container.adoc
+++ b/Quickstart_Container.adoc
@@ -113,7 +113,7 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ----
 
-=== Step 2: Container-specific settings in `config.yml` — optional
+=== Step 2 (OPTIONAL - covered in Step 3): Container-specific settings in `config.yml`
 
 The repository root **`config.yml`** holds `Container_Properties` used by *Build_Remix.sh* / *Verify_Build_Remix.sh*. You do *not* have to edit this file by hand: **`./Update_Remix_Config.sh`** (Step 3) prompts for `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version`, and `include_pxeboot_files` (PXE), writing values back to YAML safely.
 
@@ -169,7 +169,7 @@ Instead of manually editing *Container_Properties* in `config.yml` and `fedora_v
 
 [source,bash]
 ----
-chmod +x Update_Remix_Config.sh
+chmod +x Update_Remix_Config.sh   # once (if needed)
 ./Update_Remix_Config.sh
 ----
 

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -12,9 +12,10 @@ This guide walks through a **Podman-based** build: the heavy work runs in the **
 **Configuration order (recommended)**
 
 1. Clone this repo (`Fedora_Remix`) and `cd` into it.
-2. Edit root **`config.yml`** for **paths and registry only**: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**. (You can leave **`Fedora_Version`** for the next step.)
-3. Run **`./Update_Remix_Config.sh`** — sets **`Fedora_Version`**, **`fedora_version`**, and **`include_pxeboot_files`** together (avoids hand-editing two YAML files).
-4. Run **`./Verify_Build_Remix.sh`** (recommended) or **`./Build_Remix.sh`**.
+2. Run **`./Update_Remix_Config.sh`** — interactive prompts for **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**, and **`include_pxeboot_files`** (PXE). Press **Enter** at any prompt to keep the value shown in brackets (defaults come from **`config.yml`**). Optionally pre-edit **`config.yml`** so those defaults match your host (see Step 2).
+3. Run **`./Verify_Build_Remix.sh`** (recommended) or **`./Build_Remix.sh`**.
+
+> **Registry owner:** If you use the **published** builder image at **`ghcr.io/tmichett/fedora-remix-builder`**, keep **`GitHub_Registry_Owner`** set to **`tmichett`** so pulls and verification match that image.
 
 PXE payloads (`Prepare_Web_Files.py` inside the build): enable **`include_pxeboot_files`** only when you need **`vmlinuz`** / **`initrd`** staged for network boot; use **false** / answer **no** for a normal ISO-only build (see Step 3’s warning).
 
@@ -115,13 +116,11 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ```
 
-### Step 2: Container-specific settings (`config.yml`)
+### Step 2: Container-specific settings (`config.yml`) — optional
 
-Edit the repository root **`config.yml`** for values that are **not** covered by **`Update_Remix_Config.sh`**:
+The repository root **`config.yml`** holds **`Container_Properties`** used by **`Build_Remix.sh`** / **`Verify_Build_Remix.sh`**. You **do not** have to edit this file by hand: **`./Update_Remix_Config.sh`** (Step 3) prompts for **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**, and **`include_pxeboot_files`** (PXE), writing safe values back to YAML.
 
-- **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** — edit only here.
-
-You *may* set **`Fedora_Version`** here temporarily, but **`./Update_Remix_Config.sh`** (Step 3) overwrites **`Fedora_Version`** and **`Setup/config.yml`** so both stay aligned—prefer Step 3 whenever you change distro release.
+**When to edit here first:** copy in a **`config.yml`** from another machine, or set paths/registry **before** running the script—those values become the **[bracket]** defaults at each prompt. You *may* still set **`Fedora_Version`** here temporarily; Step 3 aligns **`Fedora_Version`**, **`fedora_version`** (`Setup/config.yml`), and PXE whenever you run it.
 
 ```bash
 vim config.yml
@@ -142,7 +141,7 @@ Container_Properties:
 - **`Fedora_Version`**: Fedora release embedded in `ghcr.io/.../fedora-remix-builder:{version}`; prefer setting alongside remix settings via **`Update_Remix_Config.sh`** so nothing drifts out of sync.
 - **`SSH_Key_Location`**: Path to your SSH key (used for git operations in container)
 - **`Fedora_Remix_Location`**: Where the ISO and build artifacts will be saved
-- **`GitHub_Registry_Owner`**: GitHub username/org that hosts the container image
+- **`GitHub_Registry_Owner`**: GitHub username/org used in `ghcr.io/{owner}/fedora-remix-builder:{tag}`. If you pull the **published** **`ghcr.io/tmichett/...`** image, keep this **`tmichett`** (the script reminds you before this prompt).
 
 **Example Configuration:**
 
@@ -154,16 +153,22 @@ Container_Properties:
   GitHub_Registry_Owner: "tmichett"
 ```
 
-### Step 3: Fedora release and PXE (`Update_Remix_Config.sh` — recommended)
+### Step 3: Align paths, registry, Fedora release, and PXE (`Update_Remix_Config.sh` — recommended)
 
-Instead of manually editing **`Fedora_Version`** in `config.yml` and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`**, run from the repository root:
+Instead of manually editing **`Container_Properties`** in **`config.yml`** and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`**, run from the repository root:
 
 ```bash
 chmod +x Update_Remix_Config.sh   # once
 ./Update_Remix_Config.sh
 ```
 
-The script asks for the Fedora release and whether to download **PXE Linux** boot images (`vmlinuz`, `initrd.img`) for the web prepare step. When enabled, that supports optionally using the Remix build environment for **network (PXE/HTTP) boot** content. If you answer **no**, PXE assets are skipped (`include_pxeboot_files: false`).
+**Prompts (in order)** — Enter keeps the **[bracket]** default (from **`config.yml`** if present):
+
+1. **`SSH_Key_Location`** — SSH key path for git operations inside the container workflow  
+2. **`Fedora_Remix_Location`** — host directory for ISO output and build artifacts  
+3. **`GitHub_Registry_Owner`** — used to build `ghcr.io/{owner}/fedora-remix-builder:{tag}`; the script prints a reminder that if you use the **published** image under **`ghcr.io/tmichett/...`**, this value should stay **`tmichett`**  
+4. **Fedora release** — sets **`Fedora_Version`** and **`fedora_version`** together  
+5. **PXE/Linux boot images** — whether to download **PXE Linux** artifacts (`vmlinuz`, `initrd.img`) for the web prepare step. When enabled, that supports optionally using the Remix build environment for **network (PXE/HTTP) boot** content. If you answer **no**, PXE assets are skipped (`include_pxeboot_files: false`).
 
 > **Important:** For some **older** (including EOL) or **very new** Fedora versions, those images may be **unavailable** or **not** at the standard paths **`Prepare_Web_Files.py`** uses—prepare or build can **fail**. If you are **not** using PXE/Linux network boot, answer **no**.
 
@@ -712,11 +717,10 @@ done
 **Minimum Steps to Build:**
 
 1. `git clone https://github.com/tmichett/Fedora_Remix.git` — `cd Fedora_Remix`
-2. Edit **`config.yml`** — **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
-3. **`./Update_Remix_Config.sh`** — Fedora release + **`include_pxeboot_files`** (answer **no** unless serving PXE)
-4. **`./Verify_Build_Remix.sh`** — or **`./Build_Remix.sh`** directly (`REMIX_INCLUDE_PXEBOOT=…` overrides if needed)
-5. When the streamed log exits, **`podman stop remix-builder`** (with **`sudo`** if your build did)
-6. ISO under **`{Fedora_Remix_Location}/FedoraRemix/`** — e.g. `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
+2. **`./Update_Remix_Config.sh`** — **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** (keep **`tmichett`** if using **`ghcr.io/tmichett/fedora-remix-builder`**), **`Fedora_Version`**, and **`include_pxeboot_files`** (answer **no** unless serving PXE); optional pre-edit **`config.yml`** for defaults
+3. **`./Verify_Build_Remix.sh`** — or **`./Build_Remix.sh`** directly (`REMIX_INCLUDE_PXEBOOT=…` overrides if needed)
+4. When the streamed log exits, **`podman stop remix-builder`** (with **`sudo`** if your build did)
+5. ISO under **`{Fedora_Remix_Location}/FedoraRemix/`** — e.g. `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
 
 **Optional Customization:**
 
@@ -729,4 +733,4 @@ done
 ---
 
 **Last Updated:** April 28, 2026  
-**Version:** 1.3
+**Version:** 1.4

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -7,7 +7,16 @@
 
 ## Overview
 
-This guide will walk you through building a custom Fedora Remix ISO image using the Fedora Remix Builder container. The entire build process runs in a container, making it consistent across different systems.
+This guide walks through a **Podman-based** build: the heavy work runs in the **fedora-remix-builder** container; your host mounts the repo and the ISO output directory.
+
+**Configuration order (recommended)**
+
+1. Clone this repo (`Fedora_Remix`) and `cd` into it.
+2. Edit root **`config.yml`** for **paths and registry only**: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**. (You can leave **`Fedora_Version`** for the next step.)
+3. Run **`./Update_Remix_Config.sh`** — sets **`Fedora_Version`**, **`fedora_version`**, and **`include_pxeboot_files`** together (avoids hand-editing two YAML files).
+4. Run **`./Verify_Build_Remix.sh`** (recommended) or **`./Build_Remix.sh`**.
+
+PXE payloads (`Prepare_Web_Files.py` inside the build): enable **`include_pxeboot_files`** only when you need **`vmlinuz`** / **`initrd`** staged for network boot; use **false** / answer **no** for a normal ISO-only build (see Step 3’s warning).
 
 **Build Time:** Approximately 30-45 minutes  
 **Output:** A bootable Fedora Remix ISO file (~7-8 GB)
@@ -87,7 +96,7 @@ This is not needed if you are working directly on the build machine.
 
 ### Supported Operating Systems
 
-- ✅ Fedora Linux (39, 40, 41, 42, 43)
+- ✅ Fedora Linux (39–44 and current targets; verify `ghcr.io/.../fedora-remix-builder:{N}` exists for **N**)
 - ✅ RHEL/CentOS/Rocky/Alma Linux (8, 9)
 - ✅ Ubuntu/Debian (with Podman installed)
 - ✅ macOS (with Podman Desktop)
@@ -108,7 +117,11 @@ cd Fedora_Remix
 
 ### Step 2: Container-specific settings (`config.yml`)
 
-Edit the root configuration for paths the builder container needs: **SSH key**, **ISO/output directory**, and **GitHub Container Registry owner**. You can set **`Fedora_Version`** here manually, or rely on **`Update_Remix_Config.sh`** (Step 3) to align **`Fedora_Version`** and **`Setup/config.yml`** for you.
+Edit the repository root **`config.yml`** for values that are **not** covered by **`Update_Remix_Config.sh`**:
+
+- **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`** — edit only here.
+
+You *may* set **`Fedora_Version`** here temporarily, but **`./Update_Remix_Config.sh`** (Step 3) overwrites **`Fedora_Version`** and **`Setup/config.yml`** so both stay aligned—prefer Step 3 whenever you change distro release.
 
 ```bash
 vim config.yml
@@ -177,10 +190,11 @@ Run the verification script to check your configuration:
 ```
 
 **What it checks:**
-- ✅ Fedora versions match between both config files
-- ✅ Container image availability
-- ✅ Configuration summary
-- ✅ Confirms before building
+- ✅ **`Fedora_Version`** (root **`config.yml`**) matches **`fedora_version`** (**`Setup/config.yml`**)
+- ✅ Shows **`include_pxeboot_files`** on the remix side of the summary (PXE web assets / `Prepare_Web_Files.py`)
+- ✅ If **`include_pxeboot_files`** is missing from **`Setup/config.yml`**, prompts interactively unless **`REMIX_INCLUDE_PXEBOOT`**=`true`|`false` is set in the environment
+- ✅ Resolves **`ghcr.io/{owner}/fedora-remix-builder:{tag}`** (checks / pulls container image)
+- ✅ Confirms before calling **`./Build_Remix.sh`**, forwarding **`REMIX_INCLUDE_PXEBOOT`** so the container prepare respects your PXE choice
 
 **Sample Output:**
 ```
@@ -200,12 +214,12 @@ Do you want to proceed with the build? [y/N]: y
 
 ### Step 5: Build the ISO
 
-If you used the verification script and confirmed, the build starts automatically.
+If you answered **yes** at the **`Verify_Build_Remix.sh`** prompt, **`Verify_Build_Remix.sh`** **`exec`**s **`./Build_Remix.sh`** for you — with **`REMIX_INCLUDE_PXEBOOT`** set from your **`include_pxeboot_files`** choice.
 
-Otherwise, run the build script directly:
+Otherwise run **`./Build_Remix.sh`** yourself. To force PXE off from the shell without editing YAML:
 
 ```bash
-./Build_Remix.sh
+REMIX_INCLUDE_PXEBOOT=false ./Build_Remix.sh
 ```
 
 **Build Process (default):** The script starts the container **detached** and **streams the build** by following `/tmp/entrypoint.log` **in the same terminal** (you do not need a second window or `podman exec` just to watch progress). A typical run looks like:
@@ -669,7 +683,9 @@ done
 
 ### Documentation
 
-- **Physical/virtual quickstart (Asciidoctor/PDF):** `README_Physical.adoc`
+- **AsciiDoctor index:** [docs/README.adoc](docs/README.adoc)
+- **Physical/virtual quickstart (Asciidoctor/PDF):** [README_Physical.adoc](README_Physical.adoc)
+- **This guide (AsciiDoctor):** [Quickstart_Container.adoc](Quickstart_Container.adoc)
 - **Main README:** `README.md` - Project overview
 - **Build Fixes:** `LINUX_BUILD_FIX.md` - Known issues and solutions
 - **SELinux Fix:** `SELINUX_RELABEL_FIX.md` - SELinux relabeling fix details
@@ -695,12 +711,12 @@ done
 
 **Minimum Steps to Build:**
 
-1. Clone repository: `git clone https://github.com/tmichett/Fedora_Remix.git`
-2. Edit **`config.yml`** — SSH key path, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
-3. Run **`./Update_Remix_Config.sh`** — Fedora release and PXE option (**no** recommended unless you need PXE)
-4. Run `./Verify_Build_Remix.sh` — Verify and build
-5. Wait 30–45 minutes (build log streams in the same terminal; when the follow step ends, run `podman stop remix-builder` if you are done with the container)
-6. Find ISO at `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
+1. `git clone https://github.com/tmichett/Fedora_Remix.git` — `cd Fedora_Remix`
+2. Edit **`config.yml`** — **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**
+3. **`./Update_Remix_Config.sh`** — Fedora release + **`include_pxeboot_files`** (answer **no** unless serving PXE)
+4. **`./Verify_Build_Remix.sh`** — or **`./Build_Remix.sh`** directly (`REMIX_INCLUDE_PXEBOOT=…` overrides if needed)
+5. When the streamed log exits, **`podman stop remix-builder`** (with **`sudo`** if your build did)
+6. ISO under **`{Fedora_Remix_Location}/FedoraRemix/`** — e.g. `/home/travis/Remix_Builder/FedoraRemix/FedoraRemix.iso`
 
 **Optional Customization:**
 
@@ -713,4 +729,4 @@ done
 ---
 
 **Last Updated:** April 28, 2026  
-**Version:** 1.2
+**Version:** 1.3

--- a/Quickstart_Container.md
+++ b/Quickstart_Container.md
@@ -116,7 +116,7 @@ git clone https://github.com/tmichett/Fedora_Remix.git
 cd Fedora_Remix
 ```
 
-### Step 2: Container-specific settings (`config.yml`) — optional
+### Step 2 (OPTIONAL - covered in Step 3): Container-specific settings (`config.yml`) 
 
 The repository root **`config.yml`** holds **`Container_Properties`** used by **`Build_Remix.sh`** / **`Verify_Build_Remix.sh`**. You **do not** have to edit this file by hand: **`./Update_Remix_Config.sh`** (Step 3) prompts for **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**, and **`include_pxeboot_files`** (PXE), writing safe values back to YAML.
 
@@ -158,7 +158,7 @@ Container_Properties:
 Instead of manually editing **`Container_Properties`** in **`config.yml`** and **`fedora_version`** / **`include_pxeboot_files`** in **`Setup/config.yml`**, run from the repository root:
 
 ```bash
-chmod +x Update_Remix_Config.sh   # once
+chmod +x Update_Remix_Config.sh   # once (if needed)
 ./Update_Remix_Config.sh
 ```
 

--- a/Quickstart_Physical.md
+++ b/Quickstart_Physical.md
@@ -14,7 +14,7 @@ This guide will walk you through building a custom Fedora Remix ISO image direct
 
 > **💡 Looking for the containerized method?** See **[Quickstart_Container.md](Quickstart_Container.md)** for building with containers (Podman), or use **[Build_Remix.sh](Build_Remix.sh)** to drive the builder image.
 
-**Configure first (recommended):** **[`Update_Remix_Config.sh`](Update_Remix_Config.sh)** interactively sets Fedora release and whether to stage **PXE Linux** boot artifacts (`vmlinuz`, `initrd.img` in the web tree). It updates the root **`config.yml`** (`Fedora_Version`), **`Setup/config.yml`** (`fedora_version`, `include_pxeboot_files`), replacing most manual YAML edits. See [Step 4](#step-4-fedora-release-and-pxe-update_remix_configsh) for PXE caveats on old or very new Fedora versions.
+**Configure first (recommended):** **[`Update_Remix_Config.sh`](Update_Remix_Config.sh)** interactively sets **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, Fedora release, and whether to stage **PXE Linux** boot artifacts (`vmlinuz`, `initrd.img` in the web tree). It updates the root **`config.yml`** under **`Container_Properties`**, and **`Setup/config.yml`** (`fedora_version`, `include_pxeboot_files`), replacing most manual YAML edits. If you use **`ghcr.io/tmichett/fedora-remix-builder`** from the registry later, keep **`GitHub_Registry_Owner`** **`tmichett`**. See [Step 4](#step-4-fedora-release-and-pxe-update_remix_configsh) for PXE caveats on old or very new Fedora versions.
 
 **Recommended (native build):** From the repository root, run **[`Build_Remix_Physical.sh`](Build_Remix_Physical.sh)**. It updates `Setup/config.yml` (`fedora_version`), runs `Setup/Prepare_Fedora_Remix_Build.py` and `Setup/Prepare_Web_Files.py` in the correct order, then runs **[`Setup/Enhanced_Remix_Build_Script.sh`](Setup/Enhanced_Remix_Build_Script.sh)** in `/livecd-creator/FedoraRemix` with the kickstart you choose. Use `./Build_Remix_Physical.sh -h` for options (`-v` release, `-k` kickstart, `-l` list). You can run **`Update_Remix_Config.sh`** first so version and PXE settings are already correct before this script prompts.
 
@@ -168,7 +168,7 @@ chmod +x Update_Remix_Config.sh   # once
 
 **What it configures**
 
-- Root **`config.yml`**: `Container_Properties.Fedora_Version` (keeps the tree aligned if you use container tools later or share the clone).
+- Root **`config.yml`**: `Container_Properties` — `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version` (keeps the tree aligned if you use container tools later or share the clone).
 - **`Setup/config.yml`**: `fedora_version` (must match `Fedora_Version`), and `include_pxeboot_files`.
 
 When **`include_pxeboot_files`** is **true**, **`Prepare_Web_Files.py`** downloads **PXE/Linux** installer images (`vmlinuz`, `initrd.img`) into the web tree so you can optionally use this host with **httpd** as part of a **network (PXE)** install setup for your Remix. If you answer **no**, the preparer skips those downloads (`include_pxeboot_files: false`).
@@ -726,7 +726,7 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 
 1. Install Fedora Remix (or use Fedora) and ensure sudo works
 2. `git clone https://github.com/tmichett/Fedora_Remix.git` and `cd Fedora_Remix`
-3. **`./Update_Remix_Config.sh`** to set Fedora release and PXE option (recommended; use **no** for PXE if you only need a local ISO)
+3. **`./Update_Remix_Config.sh`** to set SSH path, remix directory, **`GitHub_Registry_Owner`** (keep **`tmichett`** for **`ghcr.io/tmichett/...`**), Fedora release, and PXE (recommended; use **no** for PXE if you only need a local ISO)
 4. `./Build_Remix_Physical.sh` (set version if not already done, pick kickstart, confirm; script runs prepare + `Enhanced_Remix_Build_Script.sh`)
 5. Find the ISO under `/livecd-creator/FedoraRemix/` (e.g. `FedoraRemix.iso`)
 

--- a/Quickstart_Physical.md
+++ b/Quickstart_Physical.md
@@ -703,7 +703,7 @@ See [Quickstart_Container.md](Quickstart_Container.md) for the container method.
 - **Main README:** [README.md](README.md) - Project overview
 - **Build Fixes:** [LINUX_BUILD_FIX.md](LINUX_BUILD_FIX.md) - Known issues and solutions
 - **SELinux Fix:** [SELINUX_RELABEL_FIX.md](SELINUX_RELABEL_FIX.md) - SELinux relabeling fix details
-- **Extended Docs:** [README.adoc](README.adoc) - Detailed documentation
+- **Docs folder:** [docs/README.adoc](docs/README.adoc)
 
 ### Repository Links
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ chmod +x Update_Remix_Config.sh   # once
 ./Update_Remix_Config.sh
 ```
 
-This sets **`Fedora_Version`** (root `config.yml`), **`fedora_version`**, and **`include_pxeboot_files`** (`Setup/config.yml`). PXE boot artifacts are optional; set to **no** if you only need an ISO ([Quickstart_Container.md](Quickstart_Container.md) explains when PXE can fail on old or very new Fedora versions).
-
-Paths such as **`SSH_Key_Location`** and **`Fedora_Remix_Location`** are still edited in **`config.yml`** as needed.
+This interactively sets **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`** (root `config.yml`), plus **`fedora_version`** and **`include_pxeboot_files`** (`Setup/config.yml`). PXE boot artifacts are optional; answer **no** if you only need an ISO ([Quickstart_Container.md](Quickstart_Container.md) explains when PXE can fail on old or very new Fedora versions). If you pull the **published** image from **`ghcr.io/tmichett/fedora-remix-builder`**, keep **`GitHub_Registry_Owner`** as **`tmichett`**. You can still edit **`config.yml`** by hand first so the script’s defaults match your host (Enter at each prompt keeps the shown value).
 
 ### Building the ISO (Containerized Method - Recommended)
 
@@ -46,9 +44,8 @@ Paths such as **`SSH_Key_Location`** and **`Fedora_Remix_Location`** are still e
 
 2. **Or configure and build manually**:
    ```bash
-   ./Update_Remix_Config.sh           # preferred: keeps both YAML files in sync
-   # edit config.yml manually only for paths not covered above, e.g.:
-   # vim config.yml
+   ./Update_Remix_Config.sh           # preferred: paths, registry owner, Fedora + PXE in sync
+   # optional: vim config.yml first so script defaults match your machine
    
    # Run the build
    ./Build_Remix.sh
@@ -110,7 +107,7 @@ If you're building on Linux and encounter `/sys` unmount errors, the issue has b
 ```
 Fedora_Remix/
 ├── Build_Remix.sh              # Main build script (runs container, kickstart selection)
-├── Update_Remix_Config.sh      # Interactive: Fedora version + PXE toggle (updates config.yml + Setup/config.yml)
+├── Update_Remix_Config.sh      # Interactive: SSH path, remix dir, registry owner, Fedora + PXE (config.yml + Setup/config.yml)
 ├── config.yml                  # Build configuration
 ├── Setup/                      # Build preparation scripts
 │   ├── Enhanced_Remix_Build_Script.sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ A customized Fedora Linux live ISO with pre-configured packages, themes, and uti
 - At least 20GB free disk space
 - SSH key for GitHub access (optional)
 
+### Configuration (before your first build)
+
+From the **repository root**, align the container tag and remix web settings in one step (recommended instead of hand-editing YAML):
+
+```bash
+chmod +x Update_Remix_Config.sh   # once
+./Update_Remix_Config.sh
+```
+
+This sets **`Fedora_Version`** (root `config.yml`), **`fedora_version`**, and **`include_pxeboot_files`** (`Setup/config.yml`). PXE boot artifacts are optional; set to **no** if you only need an ISO ([Quickstart_Container.md](Quickstart_Container.md) explains when PXE can fail on old or very new Fedora versions).
+
+Paths such as **`SSH_Key_Location`** and **`Fedora_Remix_Location`** are still edited in **`config.yml`** as needed.
+
 ### Building the ISO (Containerized Method - Recommended)
 
 1. **Verify and configure** (Recommended):
@@ -26,15 +39,16 @@ A customized Fedora Linux live ISO with pre-configured packages, themes, and uti
    The verification script will:
    - ✅ Check Fedora versions match between config files
    - ✅ Verify container image availability
+   - ✅ Optionally confirm **PXE/web boot file** preference (`include_pxeboot_files`) if unset
    - ✅ Display configuration summary
    - ✅ Confirm before building
    - ✅ Automatically launch the build if approved
 
 2. **Or configure and build manually**:
    ```bash
-   # Edit config.yml with your settings
-   vim config.yml
-   vim Setup/config.yml  # Ensure fedora_version matches!
+   ./Update_Remix_Config.sh           # preferred: keeps both YAML files in sync
+   # edit config.yml manually only for paths not covered above, e.g.:
+   # vim config.yml
    
    # Run the build
    ./Build_Remix.sh
@@ -75,7 +89,9 @@ If you're building on Linux and encounter `/sys` unmount errors, the issue has b
 
 ### Getting Started
 - **[Quickstart_Container.md](Quickstart_Container.md)** - 🚀 Complete quickstart guide for containerized builds
-- **[VERIFY_BUILD_REMIX_USAGE.md](VERIFY_BUILD_REMIX_USAGE.md)** - Verification script usage guide
+- **[Quickstart_Physical.md](Quickstart_Physical.md)** - Native (physical/VM) build with `Build_Remix_Physical.sh`
+- **[VERIFY_BUILD_REMIX_USAGE.md](VERIFY_BUILD_REMIX_USAGE.md)** — `Verify_Build_Remix.sh` walkthrough
+- **[Notes/Fedora_Remix_Quickstart.md](Notes/Fedora_Remix_Quickstart.md)** - Long-form notes (RemixBuilder + kickstarts)
 
 ### Build Methods
 - **Containerized (Recommended)** - Use `./Verify_Build_Remix.sh` or `./Build_Remix.sh`
@@ -86,14 +102,15 @@ If you're building on Linux and encounter `/sys` unmount errors, the issue has b
 - **[SELINUX_RELABEL_FIX.md](SELINUX_RELABEL_FIX.md)** - SELinux relabeling error fix (April 2026)
 
 ### Reference
-- **[README_Scripts_Usage.md](README_Scripts_Usage.md)** - Complete script documentation
-- **[README.adoc](README.adoc)** - Extended documentation and detailed information
+- **[README_Scripts_Usage.md](README_Scripts_Usage.md)** - Prepare scripts, web setup, Python workflow
+- **[docs/README.adoc](docs/README.adoc)** - Short AsciiDoc readme (docs folder)
 
 ## Project Structure
 
 ```
 Fedora_Remix/
 ├── Build_Remix.sh              # Main build script (runs container, kickstart selection)
+├── Update_Remix_Config.sh      # Interactive: Fedora version + PXE toggle (updates config.yml + Setup/config.yml)
 ├── config.yml                  # Build configuration
 ├── Setup/                      # Build preparation scripts
 │   ├── Enhanced_Remix_Build_Script.sh

--- a/README_Physical.adoc
+++ b/README_Physical.adoc
@@ -33,7 +33,7 @@ chmod +x Update_Remix_Config.sh
 ./Update_Remix_Config.sh
 ----
 
-The script asks for the Fedora release and whether to download **PXE Linux** boot images for the web tree. It updates *config.yml* (*Container_Properties.Fedora_Version*), *Setup/config.yml* *fedora_version*, and *include_pxeboot_files*. When *include_pxeboot_files* is *true*, *Prepare_Web_Files.py* fetches `vmlinuz` and `initrd.img` so you can optionally use the build host (HTTPd) as part of a **PXE** / network-install layout for your Fedora Remix.
+It prompts for `SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, the Fedora release, and whether to download **PXE Linux** boot images for the web tree. It updates *config.yml* (*Container_Properties*), *Setup/config.yml* *fedora_version*, and *include_pxeboot_files*. If you use the published container image at `ghcr.io/tmichett/fedora-remix-builder`, keep `GitHub_Registry_Owner` set to `tmichett`. When *include_pxeboot_files* is *true*, *Prepare_Web_Files.py* fetches `vmlinuz` and `initrd.img` so you can optionally use the build host (HTTPd) as part of a **PXE** / network-install layout for your Fedora Remix.
 
 [IMPORTANT]
 ====
@@ -46,7 +46,7 @@ For some **older** releases, EOL composes, or **very new** Fedora versions, thos
 .. Setup a local user and ensure it is in the SUDOERS file
 .. Run some the Fedora Remix customize scripts to create SSH keys and SUDO with no password
 . Clone https://github.com/tmichett/Fedora_Remix
-. Run *Update_Remix_Config.sh* from the repository root (recommended) to align *Fedora_Version*, *fedora_version*, and PXE-related *include_pxeboot_files*; or set those values by hand in *config.yml* and *Setup/config.yml*
+. Run *Update_Remix_Config.sh* from the repository root (recommended) to align *Container_Properties* (including *Fedora_Version* and registry fields), *fedora_version*, and PXE-related *include_pxeboot_files*; or set those values by hand in *config.yml* and *Setup/config.yml*
 . Either run *Build_Remix_Physical.sh* from the repository root (recommended), or run the Python automation scripts manually with `sudo` from the *Setup* directory in this order:
 .. *Prepare_Fedora_Remix_Build.py* (creates `/livecd-creator/FedoraRemix` and copies assets)
 .. *Prepare_Web_Files.py* (HTTPd, web assets, and imgcreate `kickstart.py` / `fs.py` fixes under `/var/www/html/`)

--- a/README_Scripts_Usage.md
+++ b/README_Scripts_Usage.md
@@ -56,7 +56,7 @@ sudo dnf install -y ansible-core
 **Purpose**: Sets up the build environment for creating Fedora Remix ISOs.
 
 **What it does**:
-- Installs essential packages (`vim`, `livecd-tools`, `sshfs`)
+- Installs essential packages (`vim`, `livecd-tools`, `sshfs`; adds `util-linux-script` on Fedora 42 and later — on older releases `script(1)` comes from `util-linux`)
 - Creates build directories (`/livecd-creator/FedoraRemix`, `/livecd-creator/package-cache`)
 - Copies kickstart files to the build location
 - Copies the build script with proper permissions
@@ -70,7 +70,7 @@ sudo dnf install -y ansible-core
 
 **What it does**:
 - Installs and configures Apache HTTP server
-- Downloads Fedora boot files for PXE booting
+- When **`include_pxeboot_files`** is true (or overridden by **`REMIX_INCLUDE_PXEBOOT`**), downloads Fedora boot images for PXE; otherwise skips PXE binaries
 - Sets up web directories and file structure
 - Clones related Git repositories
 - Configures Apache for file serving
@@ -110,12 +110,16 @@ fedora_version: 42
 
 # Web root directory where files will be served
 web_root: "/var/www/html"
+
+# When false, skip downloading vmlinuz/initrd for PXE (recommended if not network-booting)
+include_pxeboot_files: false
 ```
 
 **Customization Options**:
 - `fedora_boot_files`: List of boot files to download for PXE support
 - `fedora_version`: Fedora release version for boot file downloads
 - `web_root`: Apache document root directory
+- `include_pxeboot_files`: Toggle PXE kernel/initrd fetch (align with [Update_Remix_Config.sh](Update_Remix_Config.sh) or [Quickstart_Physical.md](Quickstart_Physical.md) / [Quickstart_Container.md](Quickstart_Container.md))
 
 ### Kickstart Configuration
 
@@ -144,7 +148,7 @@ flowchart TD
     B --> D["Web Hosting Only<br/>Prepare_Web_Files.py"]
     B --> E["Complete Setup<br/>Both Build + Web"]
     
-    C --> F["Build Environment Setup<br/>• Install packages (livecd-tools, util-linux-script)<br/>• Create /livecd-creator/FedoraRemix/<br/>• Copy kickstart files<br/>• Copy Python scripts<br/>• Copy config.yml"]
+    C --> F["Build Environment Setup<br/>• Install packages (livecd-tools, sshfs; util-linux-script on F42+)<br/>• Create /livecd-creator/FedoraRemix/<br/>• Copy kickstart files<br/>• Copy Python scripts<br/>• Copy config.yml"]
     
     D --> G["Web Hosting Setup<br/>• Install Apache httpd<br/>• Download Fedora boot files<br/>• Setup /var/www/html/ structure<br/>• Clone Git repositories<br/>• Copy extensions & tools"]
     
@@ -195,7 +199,10 @@ sudo python3 Prepare_Fedora_Remix_Build.py
 # Ensure you're in the Setup directory
 cd /path/to/Fedora_Remix/Setup
 
-# Edit configuration if needed
+# Optional: edit include_pxeboot_files / fedora_version (repo root helper):
+# cd .. && ./Update_Remix_Config.sh
+
+# Edit Setup/config.yml if needed
 vim config.yml
 
 # Run the Python web setup script as root
@@ -204,7 +211,7 @@ sudo python3 Prepare_Web_Files.py
 
 **What happens**:
 - Installs and configures Apache
-- Downloads Fedora boot files for PXE
+- If enabled in config, downloads Fedora boot files for PXE
 - Sets up web directory structure
 - Clones additional repositories
 - Enables HTTP service

--- a/README_Scripts_Usage.md
+++ b/README_Scripts_Usage.md
@@ -119,7 +119,7 @@ include_pxeboot_files: false
 - `fedora_boot_files`: List of boot files to download for PXE support
 - `fedora_version`: Fedora release version for boot file downloads
 - `web_root`: Apache document root directory
-- `include_pxeboot_files`: Toggle PXE kernel/initrd fetch (align with [Update_Remix_Config.sh](Update_Remix_Config.sh) or [Quickstart_Physical.md](Quickstart_Physical.md) / [Quickstart_Container.md](Quickstart_Container.md))
+- `include_pxeboot_files`: Toggle PXE kernel/initrd fetch (align with [Update_Remix_Config.sh](Update_Remix_Config.sh), which also sets root `Container_Properties` paths and registry owner, or via [Quickstart_Physical.md](Quickstart_Physical.md) / [Quickstart_Container.md](Quickstart_Container.md))
 
 ### Kickstart Configuration
 

--- a/Update_Remix_Config.sh
+++ b/Update_Remix_Config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Update_Remix_Config.sh — Interactive update of Fedora version and PXE boot options
-# in config.yml (container) and Setup/config.yml (remix / web prepare).
+# Update_Remix_Config.sh — Interactive update of Fedora version, PXE options, and container
+# properties in config.yml plus Setup/config.yml remix settings.
 #
 
 set -e
@@ -13,17 +13,56 @@ readonly SETUP_CONFIG="$SCRIPT_DIR/Setup/config.yml"
 show_usage() {
     echo "Usage: $0 [-h|--help]"
     echo ""
-    echo "Prompts for Fedora release number and whether to include PXE boot files,"
-    echo "then updates:"
-    echo "  - config.yml              → Container_Properties.Fedora_Version"
+    echo "Interactively updates:"
+    echo "  - config.yml              → Fedora_Version, SSH_Key_Location, Fedora_Remix_Location,"
+    echo "                              GitHub_Registry_Owner (under Container_Properties)"
     echo "  - Setup/config.yml        → fedora_version, include_pxeboot_files"
+    echo ""
+    echo "Press Enter at any prompt to keep the current file value shown in [brackets]."
 }
 
-get_container_fedora_version() {
+# Rewrite one Container_Properties scalar line (YAML double-quoted value). Uses Python so
+# paths and registry names are substituted safely without sed delimiter issues.
+_yaml_set_container_field() {
+    local key="$1" value="$2"
+    python3 - "$CONTAINER_CONFIG" "$key" "$value" <<'PY'
+import pathlib, re, sys
+
+path = pathlib.Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+
+
+def dq(s: str) -> str:
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+text = path.read_text(encoding="utf-8")
+pat = rf"(^[\t ]*){re.escape(key)}:[^\n]*"
+
+def repl(m: re.Match) -> str:
+    indent = m.group(1)
+    return indent + key + ": " + dq(value)
+
+
+after, count = re.subn(pat, repl, text, count=1, flags=re.MULTILINE)
+if count != 1:
+    sys.stderr.write(f"Error: Expected exactly one '{key}' under Container_Properties in {path}\n")
+    sys.exit(1)
+path.write_text(after, encoding="utf-8")
+PY
+}
+
+get_container_field() {
+    local key="$1"
     if [ ! -f "$CONTAINER_CONFIG" ]; then
         return 1
     fi
-    grep -A 20 "Container_Properties:" "$CONTAINER_CONFIG" | grep "Fedora_Version:" | awk '{print $2}' | tr -d '"'
+    grep -A 30 "Container_Properties:" "$CONTAINER_CONFIG" | grep "^[[:space:]]*${key}:" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '"'
+}
+
+get_container_fedora_version() {
+    get_container_field Fedora_Version || true
 }
 
 get_setup_fedora_version() {
@@ -71,12 +110,7 @@ validate_fedora_version() {
 }
 
 write_container_fedora_version() {
-    local v="$1"
-    if ! grep -q '^[[:space:]]*Fedora_Version:' "$CONTAINER_CONFIG"; then
-        echo "Error: No Fedora_Version: line found in $CONTAINER_CONFIG" >&2
-        return 1
-    fi
-    sed -i "s/^\([[:space:]]*Fedora_Version:[[:space:]]*\).*/\1\"${v}\"/" "$CONTAINER_CONFIG"
+    _yaml_set_container_field Fedora_Version "$1"
 }
 
 write_setup_fedora_version() {
@@ -95,6 +129,20 @@ write_setup_include_pxeboot() {
     else
         printf '\ninclude_pxeboot_files: %s\n' "$value" >> "$SETUP_CONFIG"
     fi
+}
+
+prompt_with_default() {
+    local label="$1" default="$2"
+    local input=""
+    while true; do
+        read -r -p "${label} [${default}]: " input
+        if [ -z "$input" ]; then
+            echo "$default"
+            return
+        fi
+        echo "$input"
+        return
+    done
 }
 
 prompt_fedora_version() {
@@ -151,7 +199,21 @@ main() {
         exit 1
     fi
 
-    local cv sv default_ver pxe_default
+    local ssh_def remix_def owner_def cv sv default_ver pxe_default
+    ssh_def=$(get_container_field SSH_Key_Location || true)
+    remix_def=$(get_container_field Fedora_Remix_Location || true)
+    owner_def=$(get_container_field GitHub_Registry_Owner || true)
+
+    if [ -z "$ssh_def" ]; then
+        ssh_def='~/.ssh/github_id'
+    fi
+    if [ -z "$remix_def" ]; then
+        remix_def="/home/travis/Remix_Builder"
+    fi
+    if [ -z "$owner_def" ]; then
+        owner_def="tmichett"
+    fi
+
     cv=$(get_container_fedora_version || true)
     sv=$(get_setup_fedora_version || true)
 
@@ -166,7 +228,7 @@ main() {
 
     if [ -n "$cv" ] && [ -n "$sv" ] && [ "$cv" != "$sv" ]; then
         echo "Note: config.yml has Fedora_Version ${cv}, Setup/config.yml has fedora_version ${sv}."
-        echo "      This update will set both to the same value."
+        echo "      Fedora version prompts below set both to the same value."
         echo ""
     fi
 
@@ -180,18 +242,36 @@ main() {
     echo "Update remix configuration (container + Setup)."
     echo ""
 
-    local target_ver pxe_bool
+    echo "Container properties (saved in config.yml)."
+    echo ""
+    local ssh_val remix_val owner_val target_ver pxe_bool
+    ssh_val=$(prompt_with_default "SSH_Key_Location (git/SSH mount for the builder)" "$ssh_def")
+    remix_val=$(prompt_with_default "Fedora_Remix_Location (host path for ISO/workspace bind)" "$remix_def")
+    echo ""
+    echo "If you use the publisher images from ghcr.io/tmichett/fedora-remix-builder,"
+    echo "leave GitHub_Registry_Owner as tmichett so pulls match the published registry."
+    echo ""
+    owner_val=$(prompt_with_default "GitHub_Registry_Owner (GHCR namespace for the builder image)" "$owner_def")
+    echo ""
+
     target_ver=$(prompt_fedora_version "$default_ver")
     pxe_bool=$(prompt_pxe_boot "$pxe_default")
 
+    _yaml_set_container_field SSH_Key_Location "$ssh_val"
+    _yaml_set_container_field Fedora_Remix_Location "$remix_val"
+    _yaml_set_container_field GitHub_Registry_Owner "$owner_val"
     write_container_fedora_version "$target_ver"
     write_setup_fedora_version "$target_ver"
     write_setup_include_pxeboot "$pxe_bool"
 
     echo ""
     echo "Updated:"
-    echo "  $CONTAINER_CONFIG  → Fedora_Version \"${target_ver}\""
-    echo "  $SETUP_CONFIG      → fedora_version: ${target_ver}, include_pxeboot_files: ${pxe_bool}"
+    echo "  $CONTAINER_CONFIG"
+    echo "    → Fedora_Version \"${target_ver}\""
+    echo "    → SSH_Key_Location \"${ssh_val}\""
+    echo "    → Fedora_Remix_Location \"${remix_val}\""
+    echo "    → GitHub_Registry_Owner \"${owner_val}\""
+    echo "  $SETUP_CONFIG → fedora_version: ${target_ver}, include_pxeboot_files: ${pxe_bool}"
 }
 
 main "$@"

--- a/VERIFY_BUILD_REMIX_USAGE.md
+++ b/VERIFY_BUILD_REMIX_USAGE.md
@@ -276,7 +276,7 @@ When updating to a new Fedora version, keep **`Fedora_Version`** and **`fedora_v
 ```bash
 ./Update_Remix_Config.sh
 ```
-This updates root `config.yml` and `Setup/config.yml` together. See [Quickstart_Container.md](Quickstart_Container.md) or [Quickstart_Physical.md](Quickstart_Physical.md).
+This updates **`Container_Properties`** in root `config.yml` (`SSH_Key_Location`, `Fedora_Remix_Location`, `GitHub_Registry_Owner`, `Fedora_Version`) and `Setup/config.yml` (`fedora_version`, `include_pxeboot_files`) together. If you pull **`ghcr.io/tmichett/fedora-remix-builder`**, leave **`GitHub_Registry_Owner`** as **`tmichett`**. See [Quickstart_Container.md](Quickstart_Container.md) or [Quickstart_Physical.md](Quickstart_Physical.md).
 
 **Manual alternative:**
 1. Update `config.yml` (`Fedora_Version`)

--- a/VERIFY_BUILD_REMIX_USAGE.md
+++ b/VERIFY_BUILD_REMIX_USAGE.md
@@ -270,24 +270,22 @@ Instead of directly running:
 
 ### 3. Update Both Files Together
 
-When updating to a new Fedora version:
+When updating to a new Fedora version, keep **`Fedora_Version`** and **`fedora_version`** (and **PXE**, if you care) aligned.
 
-1. Update `config.yml`:
-   ```bash
-   vim config.yml
-   # Change Fedora_Version: "43" to "44"
-   ```
+**Recommended (from the Fedora_Remix repo root):**
+```bash
+./Update_Remix_Config.sh
+```
+This updates root `config.yml` and `Setup/config.yml` together. See [Quickstart_Container.md](Quickstart_Container.md) or [Quickstart_Physical.md](Quickstart_Physical.md).
 
-2. Update `Setup/config.yml`:
-   ```bash
-   vim Setup/config.yml
-   # Change fedora_version: 43 to 44
-   ```
+**Manual alternative:**
+1. Update `config.yml` (`Fedora_Version`)
+2. Update `Setup/config.yml` (`fedora_version`, `include_pxeboot_files` as needed)
 
-3. Verify the changes:
-   ```bash
-   ./Verify_Build_Remix.sh
-   ```
+**Then verify:**
+```bash
+./Verify_Build_Remix.sh
+```
 
 ---
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,1 +1,9 @@
-= README File
+= Fedora Remix documentation (AsciiDoctor)
+
+AsciiDoctor / PDF-friendly guides in this repository:
+
+* link:../README_Physical.adoc[*README_Physical.adoc*] — Physical / virtual-machine install narrative and workflow (historically paired with `./Build_Remix_Physical.sh`).
+* link:../Quickstart_Container.adoc[*Quickstart_Container.adoc*] — Podman/container build quickstart (**`Update_Remix_Config.sh`**, **`Verify_Build_Remix.sh`**, **`Build_Remix.sh`**).
+* link:../YAD/README.adoc[*YAD/README.adoc*] — Remix desktop tooling umbrella (where present).
+
+Portable Markdown equivalents live alongside these files (**`Quickstart_Physical.md`**, **`Quickstart_Container.md`**) for GitHub-centric reading.

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -3,7 +3,7 @@
 AsciiDoctor / PDF-friendly guides in this repository:
 
 * link:../README_Physical.adoc[*README_Physical.adoc*] — Physical / virtual-machine install narrative and workflow (historically paired with `./Build_Remix_Physical.sh`).
-* link:../Quickstart_Container.adoc[*Quickstart_Container.adoc*] — Podman/container build quickstart (**`Update_Remix_Config.sh`**, **`Verify_Build_Remix.sh`**, **`Build_Remix.sh`**).
+* link:../Quickstart_Container.adoc[*Quickstart_Container.adoc*] — Podman/container build quickstart (`Update_Remix_Config.sh` aligns SSH path, remix output dir, `GitHub_Registry_Owner`, Fedora release, PXE; **`Verify_Build_Remix.sh`**, **`Build_Remix.sh`**).
 * link:../YAD/README.adoc[*YAD/README.adoc*] — Remix desktop tooling umbrella (where present).
 
 Portable Markdown equivalents live alongside these files (**`Quickstart_Physical.md`**, **`Quickstart_Container.md`**) for GitHub-centric reading.


### PR DESCRIPTION
### Summary

This change extends **`Update_Remix_Config.sh`** so **`Container_Properties`** can be updated interactively: **`SSH_Key_Location`**, **`Fedora_Remix_Location`**, **`GitHub_Registry_Owner`**, **`Fedora_Version`**, and PXE (**`include_pxeboot_files`** in **`Setup/config.yml`**). Press **Enter** at any prompt to keep the value shown in brackets (from **`config.yml`**). Values are written with an embedded Python helper so paths and names are substituted safely.

The script prints a reminder before the registry-owner prompt: if you use the **published** builder image at **`ghcr.io/tmichett/fedora-remix-builder`**, keep **`GitHub_Registry_Owner`** set to **`tmichett`** so pulls and verification match that image.

### Documentation

Markdown and AsciiDoc quickstarts and related references are updated to describe the new prompts, optional pre-seeding of **`config.yml`**, and the **`tmichett`** / **`ghcr.io`** note.